### PR TITLE
Fix config file tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ php artisan migrate
 You can publish the config file with:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\LaravelSettings\LaravelSettingsServiceProvider" --tag="config"
+php artisan vendor:publish --provider="Spatie\LaravelSettings\LaravelSettingsServiceProvider" --tag="settings"
 ```
 
 This is the contents of the published config file:


### PR DESCRIPTION
The tag of the config is called `settings` in the `LaravelSettingsServiceProvider`. The README now reflects this.

(another options would be to make the code reflect the README of course, if you prefer :) )