### PR TITLE
Ensure that database migration path exists

### DIFF
--- a/src/Console/MakeSettingsMigrationCommand.php
+++ b/src/Console/MakeSettingsMigrationCommand.php
@@ -29,6 +29,8 @@ class MakeSettingsMigrationCommand extends Command
         $path = config('settings.migrations_path');
 
         $this->ensureMigrationDoesntAlreadyExist($name, $path);
+        
+        $this->files->ensureDirectoryExists($path);
 
         $this->files->put(
             $this->getPath($name, $path),


### PR DESCRIPTION
```
file_put_contents( {{ PATH }}): failed to open stream: No such file or directory
```

With a clean install and following the docs I ran into the above issue, this can be solved using the Filesystem