### PR TITLE
Fixes package path in make migration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ php artisan make:settings-migration CreateGeneralSettings
 This command will create a new file in `database/settings` where you can add the properties and their default values:
 
 ```php
-use Spatie\LaravelSettings\SettingsMigration;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
 
 class CreateGeneralSettings extends SettingsMigration
 {
@@ -305,7 +305,7 @@ php artisan make:settings-migration CreateGeneralSettings
 This will add a migration to the `application/database/settings` directory:
 
 ```php
-use Spatie\LaravelSettings\SettingsMigration;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
 
 class CreateGeneralSettings extends SettingsMigration
 {

--- a/src/Console/MakeSettingsMigrationCommand.php
+++ b/src/Console/MakeSettingsMigrationCommand.php
@@ -29,7 +29,7 @@ class MakeSettingsMigrationCommand extends Command
         $path = config('settings.migrations_path');
 
         $this->ensureMigrationDoesntAlreadyExist($name, $path);
-        
+
         $this->files->ensureDirectoryExists($path);
 
         $this->files->put(
@@ -43,7 +43,7 @@ class MakeSettingsMigrationCommand extends Command
         return <<<EOT
 <?php
 
-use Spatie\LaravelSettings\SettingsMigration;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
 
 class {{ class }} extends SettingsMigration
 {


### PR DESCRIPTION
Fixed an incorrect path in the stub to make a settings migrations command, also updated references in the readme.

`use Spatie\LaravelSettings\SettingsMigration;` --> `use Spatie\LaravelSettings\Migrations\SettingsMigration;`