### PR TITLE
Introduce helper functions, setting and setting_update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Store strongly typed application settings
+****# Store strongly typed application settings
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/laravel-settings.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-settings)
 [![GitHub Tests Action Status](https://img.shields.io/github/workflow/status/spatie/laravel-settings/run-tests?label=tests)](https://github.com/spatie/laravel-settings/actions?query=workflow%3Arun-tests+branch%3Amaster)
@@ -12,9 +12,9 @@ This package allows you to store settings in a repository (database, Redis, ...)
 class GeneralSettings extends Settings
 {
     public string $site_name;
-    
+
     public bool $site_active;
-    
+
     public static function group(): string
     {
         return 'general';
@@ -30,7 +30,7 @@ class GeneralSettingsController
     public function show(GeneralSettings $settings){
         return view('settings.show', [
             'site_name' => $settings->site_name,
-            'site_active' => $settings->site_active    
+            'site_active' => $settings->site_active
         ]);
     }
 }
@@ -47,9 +47,9 @@ class GeneralSettingsController
     ){
         $settings->site_name = $request->input('site_name');
         $settings->site_active = $request->input('site_active');
-        
+
         $settings->save();
-        
+
         return redirect()->back();
     }
 }
@@ -176,9 +176,9 @@ Although it is possible to use the same group for different settings classes, we
 class GeneralSettings extends Settings
 {
     public string $site_name;
-    
+
     public bool $site_active;
-    
+
     public static function group(): string
     {
         return 'general';
@@ -255,9 +255,9 @@ class SettingsController
     public function __invoke(GeneralSettings $settings, GeneralSettingsRequest $request){
         $settings->site_name = $request->input('site_name');
         $settings->site_active = $request->boolean('site_active');
-        
+
         $settings->save();
-        
+
         return redirect()->back();
     }
 }
@@ -273,14 +273,14 @@ You can explicitly set the repository of a settings class by implementing the `r
 class GeneralSettings extends Settings
 {
     public string $site_name;
-    
+
     public bool $site_active;
-    
+
     public static function group(): string
     {
         return 'general';
     }
-    
+
     public static function repository(): ?string
     {
         return 'global_settings';
@@ -361,7 +361,7 @@ It is possible to update the contents of a property:
 public function up(): void
 {
     $this->migrator->update(
-        'general.timezone', 
+        'general.timezone',
         fn(string $timezone) => return 'America/New_York'
     );
 }
@@ -387,11 +387,11 @@ public function up(): void
 {
     $this->settingsMigrator->inGroup('general', function (SettingsBlueprint $blueprint): void {
         $blueprint->add('timzone', 'Europe/Brussels');
-        
+
         $blueprint->rename('timezone', 'local_timezone');
-        
+
         $blueprint->update('timezone', fn(string $timezone) => return 'America/New_York');
-        
+
         $blueprint->delete('timezone');
     });
 }
@@ -406,15 +406,15 @@ It is possible to create a settings class with regular PHP types:
 class RegularTypeSettings extends Settings
 {
     public string $a_string;
-    
+
     public bool $a_bool;
-    
+
     public int $an_int;
-    
+
     public float $a_float;
-    
+
     public array $an_array;
-    
+
     public static function group(): string
     {
         return 'regular_ype';
@@ -434,12 +434,12 @@ Local casts work on one specific settings class and should be defined for each p
 class DateSettings extends Settings
 {
     public DateTime $birth_date;
-    
+
     public static function group(): string
     {
         return 'date';
     }
-    
+
     public static function casts(): array
     {
         return [
@@ -457,12 +457,12 @@ The `DateTimeInterfaceCast` can be used for properties with types like `DateTime
 class DateSettings extends Settings
 {
     public $birth_date;
-    
+
     public static function group(): string
     {
         return 'date';
     }
-    
+
     public static function casts(): array
     {
         return [
@@ -480,12 +480,12 @@ You can also provide arguments to a cast without constructing it:
 class DateSettings extends Settings
 {
     public $birth_date;
-    
+
     public static function group(): string
     {
         return 'date';
     }
-    
+
     public static function casts(): array
     {
         return [
@@ -510,18 +510,18 @@ You can define global casts in the `global_casts` array of the package configura
 ```
 
  A global cast can work on:
- 
+
  - a specific type (`DateTimeZone::class`)
  - a type that implements an interface (`DateTimeInterface::class`)
  - a type that extends from another class (`DataTransferObject::class`)
- 
+
 In your settings class, when you use a `DateTime` property (which implements `DateTimeInterface`), you no longer have to define local casts:
 
 ```php
 class DateSettings extends Settings
 {
     public DateTime $birth_date;
-    
+
     public static function group(): string
     {
         return 'date';
@@ -539,9 +539,9 @@ There are quite a few options to type properties. You could type them in PHP:
 class DateSettings extends Settings
 {
     public DateTime $birth_date;
-    
+
     public ?int $a_nullable_int;
-    
+
     public static function group(): string
     {
         return 'date';
@@ -556,10 +556,10 @@ class DateSettings extends Settings
 {
     /** @var \DateTime  */
     public $birth_date;
-    
+
     /** @var ?int  */
     public $a_nullable_int;
-    
+
     public static function group(): string
     {
         return 'date';
@@ -574,7 +574,7 @@ class DateSettings extends Settings
 {
     /** @var array<\DateTime>  */
     public array $birth_dates;
-    
+
     // OR
 
     /** @var \DateTime[]  */
@@ -619,14 +619,14 @@ Adding encryption to the properties of your settings class can be done as such. 
 class GeneralSettings extends Settings
 {
     public string $site_name;
-    
+
     public bool $site_active;
-    
+
     public static function group(): string
     {
         return 'general';
     }
-    
+
     public static function encrypted(): array
     {
         return [
@@ -655,7 +655,7 @@ The same goes for the `update` method, which should be replaced by `updateEncryp
 public function up(): void
 {
     $this->migrator->updateEncrypted(
-        'general.site_name', 
+        'general.site_name',
         fn(string $siteName) => return 'Space'
     );
 }
@@ -771,17 +771,17 @@ When using a local cast, there are a few different possibilities to deduce the t
 ```php
 // By the type of property
 
-class CastSettings extends Settings 
+class CastSettings extends Settings
 {
     public DateTime $birth_date;
-    
+
     public static function casts(): array
     {
         return [
             'birth_date' => DateTimeInterfaceCast::class
         ];
     }
-    
+
     ...
 }
 ```
@@ -793,14 +793,14 @@ class CastSettings extends Settings
 {
     /** @var \DateTime  */
     public $birth_date;
-    
+
     public static function casts(): array
     {
         return [
             'birth_date' => DateTimeInterfaceCast::class
         ];
     }
-    
+
     ...
 }
 ```
@@ -812,14 +812,14 @@ class CastSettings extends Settings
 class CastSettings extends Settings
 {
     public $birth_date;
-    
+
     public static function casts(): array
     {
         return [
             'birth_date' => DateTimeInterfaceCast::class.':'.DateTime::class
         ];
     }
-    
+
     ...
 }
 ```
@@ -830,14 +830,14 @@ In that last case: by explicit definition, it is possible to provide extra argum
 class CastSettings extends Settings
 {
     public $birth_date;
-    
+
     public static function casts(): array
     {
         return [
             'birth_date' => DateTimeWthTimeZoneInterfaceCast::class.':'.DateTime::class.',Europe/Brussels'
         ];
     }
-    
+
     ...
 }
 ```
@@ -848,14 +848,14 @@ Although in this case, it might be more readable to construct the caster within 
 class CastSettings extends Settings
 {
     public $birth_date;
-    
+
     public static function casts(): array
     {
         return [
             'birth_date' => new DateTimeWthTimeZoneInterfaceCast(DateTime::class, 'Europe/Brussels')
         ];
     }
-    
+
     ...
 }
 ```
@@ -874,13 +874,13 @@ A good example here is the `DateTimeInterfaceCast` we've added by default in the
     'global_casts' => [
         DateTimeInterface::class => Spatie\LaravelSettings\SettingsCasts\DateTimeInterfaceCast::class,
     ],
-    
+
     ...
 ```
 
 Whenever the package detects a `Carbon`, `CarbonImmutable`, `DateTime`, or `DateTimeImmutable` type as the type of one of a settings class's properties. It will use the `DateTimeInterfaceCast` as a caster. This because `Carbon`, `CarbonImmutable`, `DateTime` and `DateTimeImmutable` all implement `DateTimeInterface`. The key that was used in `settings.php` to represent the cast.
 
-The type injected in the caster will be the type of the property. So let's say you have a property with the type `DateTime` within your settings class. When casting this property, the `DateTimeInterfaceCast` will receive `DateTime:class` as a type. 
+The type injected in the caster will be the type of the property. So let's say you have a property with the type `DateTime` within your settings class. When casting this property, the `DateTimeInterfaceCast` will receive `DateTime:class` as a type.
 
 
 ### Repostitories
@@ -955,11 +955,43 @@ interface SettingsRepository
 }
 ```
 
-All these functions should be implemented to interact with the type of storage you're using. The `payload` parameters are raw values(`int`, `bool`, `float`, `string`, `array`). Within the `database`, and `redis` repository types, These raw values are converted to JSON. But this is not required. 
+All these functions should be implemented to interact with the type of storage you're using. The `payload` parameters are raw values(`int`, `bool`, `float`, `string`, `array`). Within the `database`, and `redis` repository types, These raw values are converted to JSON. But this is not required.
 
 It is required to return raw values again in the `getPropertiesInGroup` and `getPropertyPayload` methods.
 
 Each repository's constructor will receive a `$config` array that the user-defined for the repository within the application `settings.php` config file. It is possible to add other dependencies to the constructor. They will be injected when the repository is created.
+
+## Helper functions
+
+### setting()
+
+Get setting value from setting class, example:
+
+```php
+$app_name = setting('general', 'app_name');
+
+//with fallback (optional)
+$app_name = setting('general', 'app_name', 'fallback_value');
+```
+
+### setting_update()
+
+Update setting value in setting class, example:
+
+```php
+// @returns GeneralSettings
+$generalClass = setting_update('general', 'app_name', 'My website');
+```
+
+You may update multiple keys too, example:
+
+```php
+// @returns GeneralSettings
+$generalClass = setting_update('general', [
+    'app_name' => 'My website'
+    'colors' => ['red', 'orange']
+]);
+```
 
 ## Testing
 
@@ -987,4 +1019,3 @@ If you discover any security related issues, please email freek@spatie.be instea
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-****# Store strongly typed application settings
+# Store strongly typed application settings
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/laravel-settings.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-settings)
 [![GitHub Tests Action Status](https://img.shields.io/github/workflow/status/spatie/laravel-settings/run-tests?label=tests)](https://github.com/spatie/laravel-settings/actions?query=workflow%3Arun-tests+branch%3Amaster)

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
         "ext-redis" : "*"
     },
     "autoload": {
+        "files": [
+            "src/helpers.php"
+        ],
         "psr-4": {
             "Spatie\\LaravelSettings\\": "src"
         }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,66 @@
+<?php
+
+if (!function_exists('setting')) {
+    /**
+     * Get setting from setting group class
+     *
+     * @param string $group general_value
+     * @param string $name site_name
+     * @param  $fallback_value
+     */
+    function setting(string $group, string $name, $fallback_value = null)
+    {
+        $settingClass = app(get_setting_group_class($group));
+        return isset($settingClass->$name) ? $settingClass->$name : $fallback_value;
+    }
+}
+
+if (!function_exists('setting_update')) {
+    /**
+     * Update setting by using setting group class
+     *
+     * @param string $group general_value
+     * @param string,array $name site_name, ['site_name' => 'new website']
+     * @param $new_value
+     * @return object GeneralSettings
+     */
+    function setting_update(string $group, $name, $new_value = null)
+    {
+        $settingClass = app(get_setting_group_class($group));
+
+        if (is_array($name)) {
+            foreach ($name as $key => $value)
+                $settingClass->$key = $value;
+        } else {
+            $settingClass->$name = $new_value;
+        }
+
+        return $settingClass->save();
+    }
+}
+
+if (!function_exists('get_setting_group_class')) {
+    /**
+     * Get setting group class
+     *
+     * Incase of ClassSetting similarity,
+     * it returns the first class from settings.settings
+     *
+     * The group class name should ends with settings keyword
+     * ex: GeneralSettings
+     *
+     * @param string $group general_values
+     * @return object
+     */
+    function get_setting_group_class(string $group)
+    {
+        $group = implode('', array_map(fn ($group_piece) => ucfirst($group_piece), explode('_', $group)));
+        $groupSettings = "${group}Settings";
+        $namespace = preg_grep("~${groupSettings}~", config('settings.settings'));
+
+        if (count($namespace) > 0)
+            return array_values($namespace)[0];
+        else
+            throw new Spatie\LaravelSettings\Exceptions\MissingSettings();
+    }
+}

--- a/tests/Support/HelpersTest.php
+++ b/tests/Support/HelpersTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Spatie\LaravelSettings\Tests\Support;
+
+use Spatie\LaravelSettings\Tests\TestClasses\DummySettings;
+use Spatie\LaravelSettings\Tests\TestCase;
+use Spatie\LaravelSettings\SettingsContainer;
+use Spatie\LaravelSettings\Migrations\SettingsMigrator;
+use Spatie\LaravelSettings\Migrations\SettingsBlueprint;
+use Spatie\LaravelSettings\Exceptions\MissingSettings;
+use DateTimeZone;
+use DateTimeImmutable;
+use Carbon\Carbon;
+use Spatie\LaravelSettings\Tests\TestClasses\DummyDto;
+
+class HelpersTest extends TestCase
+{
+    private SettingsMigrator $migrator;
+
+    protected function setUp(): void
+    {
+        parent::setup();
+
+        $this->app['config']->set('settings.settings', [
+            DummySettings::class,
+        ]);
+
+        $this->migrator = resolve(SettingsMigrator::class);
+
+        $dateTime = new DateTimeImmutable('16-05-1994 12:00:00');
+        $carbon = new Carbon('16-05-1994 12:00:00');
+        $dateTimeZone = new DateTimeZone('europe/brussels');
+
+        $this->migrator->inGroup('dummy', function (SettingsBlueprint $blueprint) use ($dateTimeZone, $carbon, $dateTime): void {
+            $blueprint->add('string', 'Ruben');
+            $blueprint->add('bool', false);
+            $blueprint->add('int', 42);
+            $blueprint->add('array', ['John', 'Ringo', 'Paul', 'George']);
+            $blueprint->add('nullable_string', null);
+            $blueprint->add('default_string', null);
+            $blueprint->add('dto', ['name' => 'Freek']);
+            $blueprint->add('dto_array', [
+                ['name' => 'Seb'],
+                ['name' => 'Adriaan'],
+            ]);
+            $blueprint->add('dto_collection', [
+                ['name' => 'Seb'],
+                ['name' => 'Adriaan'],
+            ]);
+            $blueprint->add('date_time', $dateTime->format(DATE_ATOM));
+            $blueprint->add('carbon', $carbon->toAtomString());
+            $blueprint->add('nullable_date_time_zone', $dateTimeZone->getName());
+        });
+
+        resolve(SettingsContainer::class)->registerBindings();
+    }
+
+    /** @test */
+    public function it_reads_value_using_setting_helper_function()
+    {
+        $dateTime = new DateTimeImmutable('16-05-1994 12:00:00');
+        $carbon = new Carbon('16-05-1994 12:00:00');
+        $dateTimeZone = new DateTimeZone('europe/brussels');
+
+        $this->assertEquals('Ruben', setting('dummy', 'string'));
+        $this->assertFalse(setting('dummy', 'bool'));
+        $this->assertEquals(42, setting('dummy', 'int'));
+        $this->assertEquals(['John', 'Ringo', 'Paul', 'George'], setting('dummy', 'array'));
+        $this->assertNull(setting('dummy', 'nullable_string'));
+        $this->assertNull(setting('dummy', 'default_string'));
+        $this->assertEquals(new DummyDto(['name' => 'Freek']), setting('dummy', 'dto'));
+
+        $this->assertEquals([
+            new DummyDto(['name' => 'Seb']),
+            new DummyDto(['name' => 'Adriaan']),
+        ], setting('dummy', 'dto_array'));
+
+        $this->assertNull(setting('dummy', 'dto_collection'));
+
+        $this->assertEquals($dateTime, setting('dummy', 'date_time'));
+        $this->assertEquals($carbon, setting('dummy', 'carbon'));
+        $this->assertEquals($dateTimeZone, setting('dummy', 'nullable_date_time_zone'));
+    }
+
+    /** @test */
+    public function it_throws_missing_setting_exception_if_group_setting_not_found()
+    {
+        $this->expectException(MissingSettings::class);
+        setting('not_found', 'string');
+    }
+
+    /** @test */
+    public function it_updates_single_value()
+    {
+        $this->assertInstanceOf(DummySettings::class, setting_update('dummy', 'string', 'New name'));
+        $this->assertEquals('New name', setting('dummy', 'string'));
+
+        $this->assertInstanceOf(DummySettings::class, setting_update('dummy', 'bool', true));
+        $this->assertTrue(setting('dummy', 'bool'));
+
+        $this->assertInstanceOf(DummySettings::class, setting_update('dummy', 'int', 1995));
+        $this->assertEquals(1995, setting('dummy', 'int'));
+
+        $this->assertInstanceOf(DummySettings::class, setting_update('dummy', 'array', ['black', 'white']));
+        $this->assertEquals(['black', 'white'], setting('dummy', 'array'));
+
+        $this->assertInstanceOf(DummySettings::class, setting_update('dummy', 'dto', new DummyDto(['name' => 'Amro'])));
+        $this->assertEquals(new DummyDto(['name' => 'Amro']), setting('dummy', 'dto'));
+
+        $this->assertInstanceOf(DummySettings::class, setting_update('dummy', 'dto_array', [
+            new DummyDto(['name' => 'Khaled']),
+            new DummyDto(['name' => 'Freek']),
+        ]));
+        $this->assertEquals([
+            new DummyDto(['name' => 'Khaled']),
+            new DummyDto(['name' => 'Freek']),
+        ], setting('dummy', 'dto_array'));
+
+        $dateTime = new DateTimeImmutable('15-12-2020 03:00:00');
+        $this->assertInstanceOf(DummySettings::class, setting_update('dummy', 'date_time', $dateTime));
+        $this->assertEquals($dateTime, setting('dummy', 'date_time'));
+
+        $carbon = new Carbon('15-12-2020 03:00:00');
+        $this->assertInstanceOf(DummySettings::class, setting_update('dummy', 'carbon', $carbon));
+        $this->assertEquals($carbon, setting('dummy', 'carbon'));
+
+        $dateTimeZone = new DateTimeZone('africa/cairo');
+        $this->assertInstanceOf(DummySettings::class, setting_update('dummy', 'nullable_date_time_zone', $dateTimeZone));
+        $this->assertEquals($dateTimeZone, setting('dummy', 'nullable_date_time_zone'));
+    }
+
+    /** @test */
+    public function it_updates_multiple_values()
+    {
+        $dateTime = new DateTimeImmutable('26-08-1995 12:00:00');
+        $carbon = new Carbon('26-08-1995 12:00:00');
+        $dateTimeZone = new DateTimeZone('europe/london');
+
+        $update_settings = setting_update('dummy', [
+            'string' => 'Hello world',
+            'bool' => false,
+            'int' => 3100,
+            'array' => ['orange', 'gray'],
+            'dto' => new DummyDto(['name' => 'Freek']),
+            'dto_array' => [
+                new DummyDto(['name' => 'John']),
+                new DummyDto(['name' => 'Paul']),
+            ],
+            'date_time' => $dateTime,
+            'carbon' => $carbon,
+            'nullable_date_time_zone' => $dateTimeZone,
+        ]);
+
+        $this->assertInstanceOf(DummySettings::class, $update_settings);
+        $this->assertEquals('Hello world', setting('dummy', 'string'));
+        $this->assertFalse(setting('dummy', 'bool'));
+        $this->assertEquals(3100, setting('dummy', 'int'));
+        $this->assertEquals(['orange', 'gray'], setting('dummy', 'array'));
+        $this->assertEquals(new DummyDto(['name' => 'Freek']), setting('dummy', 'dto'));
+
+        $this->assertEquals([
+            new DummyDto(['name' => 'John']),
+            new DummyDto(['name' => 'Paul']),
+        ], setting('dummy', 'dto_array'));
+
+        $this->assertEquals($dateTime, setting('dummy', 'date_time'));
+        $this->assertEquals($carbon, setting('dummy', 'carbon'));
+        $this->assertEquals($dateTimeZone, setting('dummy', 'nullable_date_time_zone'));
+    }
+}


### PR DESCRIPTION
New `setting()` and `setting_update()` helper functions. I created new `src/helpers.php` and added it to `composer.json` autoload.

## How to use

### setting()

Get setting value from setting class, example:

```php
$app_name = setting('general', 'app_name');

//with fallback (optional)
$app_name = setting('general', 'app_name', 'fallback_value');
```

### setting_update()

Update setting value in setting class, example:

```php
// @returns GeneralSettings
$generalClass = setting_update('general', 'app_name', 'My website');
```

You may update multiple keys too, example:

```php
// @returns GeneralSettings
$generalClass = setting_update('general', [
    'app_name' => 'My website'
    'colors' => ['red', 'orange']
]);
```

## Testing

I added test file class `HelpersTest` under namespace `Spatie\LaravelSettings\Tests\Support`, and tests ran successfully.