### PR TITLE
Fix simple typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ class RegularTypeSettings extends Settings
     
     public static function group(): string
     {
-        return 'regular_ype';
+        return 'regular_type';
     }
 }
 ```


### PR DESCRIPTION
Fixes `regular_ype` to `regular_type`