### PR TITLE
add original properties for easier logging

### DIFF
--- a/src/Events/SavingSettings.php
+++ b/src/Events/SavingSettings.php
@@ -11,11 +11,11 @@ class SavingSettings
 
     public Collection $properties;
 
-    public Collection $old;
+    public ?Collection $old;
 
     public function __construct(
         Collection $properties,
-        Collection $old,
+        ?Collection $old,
         Settings $settings
     ) {
         $this->properties = $properties;

--- a/src/Events/SavingSettings.php
+++ b/src/Events/SavingSettings.php
@@ -11,16 +11,16 @@ class SavingSettings
 
     public Collection $properties;
 
-    public ?Collection $old;
+    public ?Collection $originalValues;
 
     public function __construct(
         Collection $properties,
-        ?Collection $old,
+        ?Collection $originalValues,
         Settings $settings
     ) {
         $this->properties = $properties;
 
-        $this->old = $old;
+        $this->originalValues = $originalValues;
 
         $this->settings = $settings;
     }

--- a/src/Events/SavingSettings.php
+++ b/src/Events/SavingSettings.php
@@ -11,11 +11,16 @@ class SavingSettings
 
     public Collection $properties;
 
+    public Collection $old;
+
     public function __construct(
         Collection $properties,
+        Collection $old,
         Settings $settings
     ) {
         $this->properties = $properties;
+
+        $this->old = $old;
 
         $this->settings = $settings;
     }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -23,7 +23,7 @@ abstract class Settings implements Arrayable, Jsonable, Responsable, Serializabl
 
     private bool $configInitialized = false;
 
-    protected $originalSettingProperties;
+    protected ?Collection $originalValues = null;
 
     abstract public static function group(): string;
 
@@ -117,11 +117,11 @@ abstract class Settings implements Arrayable, Jsonable, Responsable, Serializabl
     {
         $properties = $this->toCollection();
 
-        event(new SavingSettings($properties, $this->originalSettingProperties, $this));
+        event(new SavingSettings($properties, $this->originalValues, $this));
 
         $values = $this->mapper->save(static::class, $properties);
         $this->fill($values);
-        $this->originalSettingProperties = $values;
+        $this->originalValues = $values;
 
         event(new SettingsSaved($this));
 
@@ -185,6 +185,7 @@ abstract class Settings implements Arrayable, Jsonable, Responsable, Serializabl
         $properties = unserialize($serialized);
 
         $this->fill($properties);
+        $this->originalValues = collect($properties);
         $this->loaded = true;
     }
 
@@ -198,7 +199,7 @@ abstract class Settings implements Arrayable, Jsonable, Responsable, Serializabl
 
         $this->loaded = true;
         $this->fill($values);
-        $this->originalSettingProperties = $values;
+        $this->originalValues = collect($values);
 
         event(new SettingsLoaded($this));
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -23,6 +23,8 @@ abstract class Settings implements Arrayable, Jsonable, Responsable, Serializabl
 
     private bool $configInitialized = false;
 
+    protected $originalSettingProperties;
+
     abstract public static function group(): string;
 
     public static function repository(): ?string
@@ -115,9 +117,11 @@ abstract class Settings implements Arrayable, Jsonable, Responsable, Serializabl
     {
         $properties = $this->toCollection();
 
-        event(new SavingSettings($properties, $this));
+        event(new SavingSettings($properties, $this->originalSettingProperties, $this));
 
-        $this->fill($this->mapper->save(static::class, $properties));
+        $values = $this->mapper->save(static::class, $properties);
+        $this->fill($values);
+        $this->originalSettingProperties = $values;
 
         event(new SettingsSaved($this));
 
@@ -194,6 +198,7 @@ abstract class Settings implements Arrayable, Jsonable, Responsable, Serializabl
 
         $this->loaded = true;
         $this->fill($values);
+        $this->originalSettingProperties = $values;
 
         event(new SettingsLoaded($this));
 

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -341,10 +341,15 @@ class SettingsTest extends TestCase
 
         $this->migrateDummySimpleSettings();
 
-        $settings = resolve(DummySimpleSettings::class)->save();
+        $settings = resolve(DummySimpleSettings::class);
+        $settings->name = 'New Name';
+        $settings->save();
 
         Event::assertDispatched(SavingSettings::class, function (SavingSettings $event) use ($settings) {
             $this->assertCount(2, $event->properties);
+            $this->assertEquals('New Name', $event->settings->name);
+            $this->assertCount(2, $event->originalValues);
+            $this->assertEquals('Louis Armstrong', $event->originalValues['name']);
             $this->assertEquals($settings, $event->settings);
 
             return true;


### PR DESCRIPTION
This goes to add the original properties into the settings class to allow activity logging. This takes the simpler approach like eloquent takes with just having a copy of the original properties alongside the settings rather than an explicit database call to reload properties we could already have.