### PR TITLE
Added empty array as fallback for settings.auto_discover_settings.

### DIFF
--- a/src/SettingsContainer.php
+++ b/src/SettingsContainer.php
@@ -72,7 +72,7 @@ class SettingsContainer
     protected function discoverSettings(): array
     {
         return (new DiscoverSettings())
-            ->within(config('settings.auto_discover_settings'))
+            ->within(config('settings.auto_discover_settings', []))
             ->useBasePath(base_path())
             ->ignoringFiles(Composer::getAutoloadedFiles(base_path('composer.json')))
             ->discover();


### PR DESCRIPTION
When the config is already cached, it is missing the `settings.auto_discover_settings` setting.
So `config('settings.auto_discover_settings')` returns `null`.

This produces the error ` Spatie\LaravelSettings\Support\DiscoverSettings::within(): Argument #1 ($directories) must be of type array, null given`.

The within function of DiscoverSettings only accepts an array, so I added an array as the default value.

it is also possible to change the function to `within(array $directories = [])`. I don't know what is better.