### PR TITLE
Feature/settings eloquent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 .idea
 .php_cs.cache
 .php-cs-fixer.cache
+.history

--- a/src/Events/SavingSettings.php
+++ b/src/Events/SavingSettings.php
@@ -3,7 +3,7 @@
 namespace Spatie\LaravelSettings\Events;
 
 use Illuminate\Support\Collection;
-use Spatie\LaravelSettings\Settings;
+use Spatie\LaravelSettings\Interfaces\Settings;
 
 class SavingSettings
 {

--- a/src/Events/SettingsLoaded.php
+++ b/src/Events/SettingsLoaded.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\LaravelSettings\Events;
 
-use Spatie\LaravelSettings\Settings;
+use Spatie\LaravelSettings\Interfaces\Settings;
 
 class SettingsLoaded
 {

--- a/src/Events/SettingsSaved.php
+++ b/src/Events/SettingsSaved.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\LaravelSettings\Events;
 
-use Spatie\LaravelSettings\Settings;
+use Spatie\LaravelSettings\Interfaces\Settings;
 
 class SettingsSaved
 {

--- a/src/Interfaces/Settings.php
+++ b/src/Interfaces/Settings.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\LaravelSettings\Interfaces;
+
+interface Settings
+{
+
+}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -6,9 +6,10 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Responsable;
 use Spatie\LaravelSettings\Traits\SettingsTrait;
+use Spatie\LaravelSettings\Interfaces\Settings as InterfacesSettings;
 use Serializable;
 
-abstract class Settings implements Arrayable, Jsonable, Responsable, Serializable
+abstract class Settings implements Arrayable, Jsonable, Responsable, Serializable, InterfacesSettings
 {
     use SettingsTrait;
 

--- a/src/SettingsCache.php
+++ b/src/SettingsCache.php
@@ -6,6 +6,7 @@ use Cache;
 use Illuminate\Support\Collection;
 use Spatie\LaravelSettings\Exceptions\CouldNotUnserializeSettings;
 use Spatie\LaravelSettings\Exceptions\SettingsCacheDisabled;
+use Spatie\LaravelSettings\Interfaces\Settings;
 
 class SettingsCache
 {

--- a/src/SettingsConfig.php
+++ b/src/SettingsConfig.php
@@ -32,16 +32,22 @@ class SettingsConfig
 
     public function __construct(string $settingsClass)
     {
-        if (! is_subclass_of($settingsClass, Settings::class)) {
-            throw new Exception("Tried decorating {$settingsClass} which is not extending `Spatie\LaravelSettings\Settings::class`");
+        if (! is_subclass_of($settingsClass, Settings::class) && !is_subclass_of($settingsClass, SettingsEloquent::class)) {
+                throw new Exception("Tried decorating {$settingsClass} which is not extending `Spatie\LaravelSettings\Settings::class`");
         }
-
+        $exceptProperties = [
+            'snakeAttributes' => 0,
+            'encrypter' => 0,
+            'manyMethods' => 0,
+            'incrementing' => 0,
+            'preventsLazyLoading' => 0,
+            'exists'=> 0,
+         'wasRecentlyCreated' => 0];
         $this->settingsClass = $settingsClass;
-
         $this->reflectionProperties = collect(
             (new ReflectionClass($settingsClass))->getProperties(ReflectionProperty::IS_PUBLIC)
-        )->mapWithKeys(fn (ReflectionProperty $property) => [$property->getName() => $property]);
-
+        )->mapWithKeys(fn (ReflectionProperty $property) => [$property->getName() => $property])
+        ->diffKeys($exceptProperties);
         $this->casts = $this->reflectionProperties
             ->map(fn (ReflectionProperty $reflectionProperty) => SettingsCastFactory::resolve(
                 $reflectionProperty,

--- a/src/SettingsEloquent.php
+++ b/src/SettingsEloquent.php
@@ -2,15 +2,17 @@
 
 namespace Spatie\LaravelSettings;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Responsable;
 use Spatie\LaravelSettings\Traits\SettingsTrait;
 use Serializable;
 
-abstract class Settings implements Arrayable, Jsonable, Responsable, Serializable
+abstract class SettingsEloquent extends Model implements Arrayable, Jsonable, Responsable, Serializable
 {
     use SettingsTrait;
+
 
     abstract public static function group(): string;
 
@@ -42,4 +44,11 @@ abstract class Settings implements Arrayable, Jsonable, Responsable, Serializabl
         $this->loadValues($values);
     }
 
+    public function __get($name)
+    {
+        $this->loadValues();
+
+        // return $this->$name;
+        return $this->getAttribute($name);
+    }
 }

--- a/src/SettingsEloquent.php
+++ b/src/SettingsEloquent.php
@@ -8,8 +8,9 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Responsable;
 use Spatie\LaravelSettings\Traits\SettingsTrait;
 use Serializable;
+use Spatie\LaravelSettings\Interfaces\Settings;
 
-abstract class SettingsEloquent extends Model implements Arrayable, Jsonable, Responsable, Serializable
+abstract class SettingsEloquent extends Model implements Arrayable, Jsonable, Responsable, Serializable, Settings
 {
     use SettingsTrait;
 

--- a/src/Support/DiscoverSettings.php
+++ b/src/Support/DiscoverSettings.php
@@ -4,6 +4,7 @@ namespace Spatie\LaravelSettings\Support;
 
 use Illuminate\Support\Str;
 use Spatie\LaravelSettings\Settings;
+use Spatie\LaravelSettings\SettingsEloquent;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 use Throwable;
@@ -58,13 +59,12 @@ class DiscoverSettings
         }
 
         $files = (new Finder())->files()->in($this->directories);
-
         return collect($files)
             ->reject(fn (SplFileInfo $file) => in_array($file->getPathname(), $this->ignoredFiles))
             ->map(fn (SplFileInfo $file) => $this->fullQualifiedClassNameFromFile($file))
             ->filter(function (string $settingsClass) {
                 try {
-                    return is_subclass_of($settingsClass, Settings::class);
+                    return (is_subclass_of($settingsClass, Settings::class) || is_subclass_of($settingsClass, SettingsEloquent::class));
                 } catch (Throwable $e) {
                     return false;
                 }

--- a/src/Traits/SettingsTrait.php
+++ b/src/Traits/SettingsTrait.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Spatie\LaravelSettings\Traits;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Collection;
+use ReflectionProperty;
+use Spatie\LaravelSettings\Events\SavingSettings;
+use Spatie\LaravelSettings\Events\SettingsLoaded;
+use Spatie\LaravelSettings\Events\SettingsSaved;
+use Spatie\LaravelSettings\SettingsConfig;
+use Spatie\LaravelSettings\SettingsMapper;
+use Spatie\LaravelSettings\SettingsRepositories\SettingsRepository;
+
+trait SettingsTrait
+{
+    private SettingsMapper $mapper;
+
+    private SettingsConfig $config;
+
+    private bool $loaded = false;
+
+    private bool $configInitialized = false;
+
+    protected ?Collection $originalValues = null;
+
+    public static function repository(): ?string
+    {
+        return null;
+    }
+
+    public static function casts(): array
+    {
+        return [];
+    }
+
+    public static function encrypted(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param array $values
+     *
+     * @return static
+     */
+    public static function fake(array $values): self
+    {
+        $settingsMapper = app(SettingsMapper::class);
+
+        $propertiesToLoad = $settingsMapper->initialize(static::class)
+            ->getReflectedProperties()
+            ->keys()
+            ->reject(fn (string $name) => array_key_exists($name, $values));
+
+        $mergedValues = $settingsMapper
+            ->fetchProperties(static::class, $propertiesToLoad)
+            ->merge($values)
+            ->toArray();
+
+        return app(Container::class)->instance(static::class, new static(
+            $mergedValues
+        ));
+    }
+
+    public function __construct(array $values = [])
+    {
+        $this->ensureConfigIsLoaded();
+
+        foreach ($this->config->getReflectedProperties()->keys() as $name) {
+            unset($this->{$name});
+        }
+
+        if (! empty($values)) {
+            $this->loadValues($values);
+        }
+    }
+
+    public function __get($name)
+    {
+        $this->loadValues();
+
+        return $this->$name;
+    }
+
+    public function __set($name, $value)
+    {
+        $this->loadValues();
+
+        $this->{$name} = $value;
+    }
+
+    public function __debugInfo()
+    {
+        $this->loadValues();
+    }
+
+    /**
+     * @param \Illuminate\Support\Collection|array $properties
+     *
+     * @return $this
+     */
+    public function fill($properties): self
+    {
+        foreach ($properties as $name => $payload) {
+            $this->{$name} = $payload;
+        }
+
+        return $this;
+    }
+
+    public function save(array $options = []): self
+    {
+        $properties = $this->toCollection();
+
+        event(new SavingSettings($properties, $this->originalValues, $this));
+
+        $values = $this->mapper->save(static::class, $properties);
+
+        $this->fill($values);
+        $this->originalValues = $values;
+
+        event(new SettingsSaved($this));
+
+        return $this;
+    }
+
+    public function lock(string ...$properties)
+    {
+        $this->ensureConfigIsLoaded();
+
+        $this->config->lock(...$properties);
+    }
+
+    public function unlock(string ...$properties)
+    {
+        $this->ensureConfigIsLoaded();
+
+        $this->config->unlock(...$properties);
+    }
+
+    public function getLockedProperties(): array
+    {
+        $this->ensureConfigIsLoaded();
+
+        return $this->config->getLocked()->toArray();
+    }
+
+    public function toCollection(): Collection
+    {
+        $this->ensureConfigIsLoaded();
+
+        return $this->config
+            ->getReflectedProperties()
+            ->mapWithKeys(fn (ReflectionProperty $property) => [
+                $property->getName() => $this->{$property->getName()},
+            ]);
+    }
+
+    public function getRepository(): SettingsRepository
+    {
+        $this->ensureConfigIsLoaded();
+
+        return $this->config->getRepository();
+    }
+
+    public function refresh(): self
+    {
+        $this->config->clearCachedLockedProperties();
+
+        $this->loaded = false;
+        $this->loadValues();
+
+        return $this;
+    }
+
+    private function loadValues(?array $values = null): self
+    {
+        if ($this->loaded) {
+            return $this;
+        }
+
+        $values ??= $this->mapper->load(static::class);
+
+        $this->loaded = true;
+
+        $this->fill($values);
+        $this->originalValues = collect($values);
+
+        event(new SettingsLoaded($this));
+
+        return $this;
+    }
+
+    private function ensureConfigIsLoaded(): self
+    {
+        if ($this->configInitialized) {
+            return $this;
+        }
+
+        $this->mapper = app(SettingsMapper::class);
+        $this->config = $this->mapper->initialize(static::class);
+        $this->configInitialized = true;
+
+        return $this;
+    }
+}

--- a/tests/Console/CacheDiscoveredSettingsCommandTest.php
+++ b/tests/Console/CacheDiscoveredSettingsCommandTest.php
@@ -5,6 +5,7 @@ namespace Spatie\LaravelSettings\Tests\Console;
 use Spatie\LaravelSettings\SettingsContainer;
 use Spatie\LaravelSettings\Tests\TestCase;
 use Spatie\LaravelSettings\Tests\TestClasses\DummySettings;
+use Spatie\LaravelSettings\Tests\TestClasses\DummySettingsEloquent;
 use Spatie\LaravelSettings\Tests\TestClasses\DummySimpleSettings;
 use Spatie\Snapshots\MatchesSnapshots;
 
@@ -21,6 +22,7 @@ class CacheDiscoveredSettingsCommandTest extends TestCase
         $this->app['config']->set('settings.settings', [
             DummySettings::class,
             DummySimpleSettings::class,
+            DummySettingsEloquent::class
         ]);
 
         $this->container = app(SettingsContainer::class);

--- a/tests/Console/ClearDiscoveredSettingsCacheCommandTest.php
+++ b/tests/Console/ClearDiscoveredSettingsCacheCommandTest.php
@@ -5,6 +5,7 @@ namespace Spatie\LaravelSettings\Tests\Console;
 use Spatie\LaravelSettings\SettingsContainer;
 use Spatie\LaravelSettings\Tests\TestCase;
 use Spatie\LaravelSettings\Tests\TestClasses\DummySettings;
+use Spatie\LaravelSettings\Tests\TestClasses\DummySettingsEloquent;
 use Spatie\LaravelSettings\Tests\TestClasses\DummySimpleSettings;
 
 class ClearDiscoveredSettingsCacheCommandTest extends TestCase
@@ -18,6 +19,8 @@ class ClearDiscoveredSettingsCacheCommandTest extends TestCase
         $this->app['config']->set('settings.settings', [
             DummySettings::class,
             DummySimpleSettings::class,
+            DummySettingsEloquent::class
+
         ]);
 
         $this->settingsContainer = app(SettingsContainer::class);

--- a/tests/Console/__snapshots__/CacheDiscoveredSettingsCommandTest__it_can_cache_the_registered_sessions__1.txt
+++ b/tests/Console/__snapshots__/CacheDiscoveredSettingsCommandTest__it_can_cache_the_registered_sessions__1.txt
@@ -1,4 +1,5 @@
 <?php return array (
   0 => 'Spatie\\LaravelSettings\\Tests\\TestClasses\\DummySettings',
   1 => 'Spatie\\LaravelSettings\\Tests\\TestClasses\\DummySimpleSettings',
+  2 => 'Spatie\\LaravelSettings\\Tests\\TestClasses\\DummySettingsEloquent',
 );

--- a/tests/Console/__snapshots__/CacheSettingsCommandTest__it_can_cache_the_registered_projectors__1.txt
+++ b/tests/Console/__snapshots__/CacheSettingsCommandTest__it_can_cache_the_registered_projectors__1.txt
@@ -1,4 +1,5 @@
 <?php return array (
   0 => 'Spatie\\LaravelSettings\\Tests\\TestClasses\\DummySettings',
   1 => 'Spatie\\LaravelSettings\\Tests\\TestClasses\\DummySimpleSettings',
+  2 => 'Spatie\\LaravelSettings\\Tests\\TestClasses\\DummySettingsEloquent',
 );

--- a/tests/DiscoversSettingsTest.php
+++ b/tests/DiscoversSettingsTest.php
@@ -6,6 +6,7 @@ use Spatie\LaravelSettings\Support\Composer;
 use Spatie\LaravelSettings\Support\DiscoverSettings;
 use Spatie\LaravelSettings\Tests\TestClasses\DummyEncryptedSettings;
 use Spatie\LaravelSettings\Tests\TestClasses\DummySettings;
+use Spatie\LaravelSettings\Tests\TestClasses\DummySettingsEloquent;
 use Spatie\LaravelSettings\Tests\TestClasses\DummySimpleSettings;
 
 class DiscoversSettingsTest extends TestCase
@@ -21,11 +22,11 @@ class DiscoversSettingsTest extends TestCase
             ->useRootNamespace('Spatie\LaravelSettings\\')
             ->ignoringFiles(Composer::getAutoloadedFiles($pathToComposerJson))
             ->discover();
-
         $this->assertEqualsCanonicalizing([
             DummySimpleSettings::class,
             DummySettings::class,
             DummyEncryptedSettings::class,
+            DummySettingsEloquent::class
         ], $discovered);
     }
 }

--- a/tests/SettingsContainerTest.php
+++ b/tests/SettingsContainerTest.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\DB;
 use Spatie\LaravelSettings\Migrations\SettingsBlueprint;
 use Spatie\LaravelSettings\Migrations\SettingsMigrator;
 use Spatie\LaravelSettings\SettingsContainer;
+use Spatie\LaravelSettings\Tests\TestClasses\DummyEncryptedSettings;
+use Spatie\LaravelSettings\Tests\TestClasses\DummySettingsEloquent;
 use Spatie\LaravelSettings\Tests\TestClasses\DummySimpleSettings;
 use Spatie\LaravelSettings\Tests\TestClasses\FakeAction;
 

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -25,6 +25,7 @@ use Spatie\LaravelSettings\SettingsCache;
 use Spatie\LaravelSettings\Tests\TestClasses\DummyDto;
 use Spatie\LaravelSettings\Tests\TestClasses\DummyEncryptedSettings;
 use Spatie\LaravelSettings\Tests\TestClasses\DummySettings;
+use Spatie\LaravelSettings\Tests\TestClasses\DummySettingsEloquent;
 use Spatie\LaravelSettings\Tests\TestClasses\DummySimpleSettings;
 use Spatie\Snapshots\MatchesSnapshots;
 
@@ -622,11 +623,23 @@ class SettingsTest extends TestCase
     public function it_can_check_if_a_property_has_been_set_if_properties_are_not_loaded()
     {
         $this->migrateDummySimpleSettings();
-
         /** @var \Spatie\LaravelSettings\Tests\TestClasses\DummySimpleSettings $settings */
         $settings = resolve(DummySimpleSettings::class);
 
-        $this->assertFalse(empty($settings->name));
+        $this->assertEquals($settings->name, 'Louis Armstrong');
+        $this->assertTrue(empty($settings->non_existing));
+    }
+
+
+    /** @test */
+    public function it_can_use_settings_eloquent()
+    {
+        $this->migrateDummySettingsEloquent();
+        /** @var \Spatie\LaravelSettings\Tests\TestClasses\DummySettingsEloquent $settings */
+        $settings = resolve(DummySettingsEloquent::class);
+        // Check GetMuttur
+        $this->assertEquals($settings->full_name, 'Louis Armstrong');
+
         $this->assertTrue(empty($settings->non_existing));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -137,4 +137,21 @@ class TestCase extends BaseTestCase
             "The setting {$group}.{$name} should not exist in the database"
         );
     }
+
+
+    protected function migrateDummySettingsEloquent(
+        string $fname = 'Louis',
+        string $lname = 'Armstrong',
+        string $description = 'Hello Dolly'
+    ): self {
+        resolve(SettingsMigrator::class)->inGroup('settings_eloquent', function (SettingsBlueprint $blueprint)
+            use ($description, $fname, $lname): void {
+            $blueprint->add('fname', $fname);
+            $blueprint->add('lname', $lname);
+            $blueprint->add('description', $description);
+            $blueprint->add('timestamps', now());
+        });
+
+        return $this;
+    }
 }

--- a/tests/TestClasses/DummySettingsEloquent.php
+++ b/tests/TestClasses/DummySettingsEloquent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\LaravelSettings\Tests\TestClasses;
+
+use Spatie\LaravelSettings\SettingsEloquent;
+
+class DummySettingsEloquent extends SettingsEloquent
+{
+    public string $fname;
+
+    public string $lname;
+
+    public string $description;
+
+    public static function group(): string
+    {
+        return 'settings_eloquent';
+    }
+
+    public function getFullNameAttribute()
+    {
+        return $this->fname . ' ' . $this->lname;
+    }
+}


### PR DESCRIPTION
I made a new Abstract Class Called SettingsEloquent that extends the Eloquent Model
and change in the base to workaround events
and now can a user select to work with normal Settings class or SettingsEloquent class
when he/she create his own Model

also for not repeating the code, I made a trait that has all functions and variables that used in Settings Class

and used it in settings and SettingsEloquent

and in SettingsEloquent I overriding the __get function to use getAttribute function from Illuminate\Database\Eloquent\Model

to be allowed to use getMutator and normal eloquent functions

and check all unit testing it passed

also, make a new test for check getMutator and it worked normally

can I make a pull request to check together if you have time because it first time I contribute an open-source project and I'm really exciting to give community some help