### PR TITLE
Ignore abstract class when discovering

### DIFF
--- a/src/Support/DiscoverSettings.php
+++ b/src/Support/DiscoverSettings.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Str;
 use Spatie\LaravelSettings\Settings;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
+use ReflectionClass;
 use Throwable;
 
 class DiscoverSettings
@@ -64,7 +65,8 @@ class DiscoverSettings
             ->map(fn (SplFileInfo $file) => $this->fullQualifiedClassNameFromFile($file))
             ->filter(function (string $settingsClass) {
                 try {
-                    return is_subclass_of($settingsClass, Settings::class);
+                    return is_subclass_of($settingsClass, Settings::class) && 
+                        !(new ReflectionClass($settingsClass))->isAbstract();
                 } catch (Throwable $e) {
                     return false;
                 }

--- a/src/Support/DiscoverSettings.php
+++ b/src/Support/DiscoverSettings.php
@@ -66,7 +66,7 @@ class DiscoverSettings
             ->filter(function (string $settingsClass) {
                 try {
                     return is_subclass_of($settingsClass, Settings::class) && 
-                        !(new ReflectionClass($settingsClass))->isAbstract();
+                        (new ReflectionClass($settingsClass))->isInstantiable();
                 } catch (Throwable $e) {
                     return false;
                 }


### PR DESCRIPTION
Hi, 

I have made abstract class to extend in local project

```
app
    - Setting
         - BaseSetting.php < - base setting
         - MySetting.php < --- setting
         
```

```php
<?php

namespace App\Setting;

use Spatie\LaravelSettings\Settings;

abstract class BaseSetting extends Settings
{
   // all setting class level will inherit
}
```
```php
<?php

namespace App\Setting;

class MySetting extends BaseSetting
{
    public ?MyType $my_field = null;

    public static function group(): string
    {
        return 'my-group';
    }
}
```

because of this, it will return on updating using migrator

```php

        $settingMigrator = app(SettingsMigrator::class);

        $settingMigrator->inGroup(MySetting::group(), function (SettingsBlueprint $settingsBlueprint) {
            foreach (
                [
                    'my_field' => <value>,
// ............
                ] as $field => $data
            ) {
                $settingsBlueprint->update($field, fn($payload) => $payload);
            }
        });

```
   Error 

  Cannot call abstract method Spatie\LaravelSettings\Settings::group()

  at vendor/spatie/laravel-settings/src/Migrations/SettingsMigrator.php:183
    179▕             ->getSettingClasses()
    180▕             ->mapWithKeys(function (string $settingsClass) {
    181▕ //                rd($settingsClass);
    182▕               return  [
  ➜ 183▕                     $settingsClass::group() => new SettingsConfig($settingsClass),
    184▕                 ];
    185▕             });
    186▕     }
    187▕ }

```