### PR TITLE
Added possibility to check if setting is locked or unlocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,18 @@ Unlocking settings can be done as such:
 $dateSettings->unlock('birth_date', 'name', 'email');
 ```
 
+Checking if a setting is currently locked can be done as such:
+
+```php
+$dateSettings->isLocked('birth_date');
+```
+
+Checking if a setting is currently unlocked can be done as such:
+
+```php
+$dateSettings->isUnlocked('birth_date');
+```
+
 ### Encrypting properties
 
 Some properties in your settings class can be confidential, like API keys, for example. It is possible to encrypt some of your properties, so it won't be possible to read them when your repository data was compromised.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -150,6 +150,16 @@ abstract class Settings implements Arrayable, Jsonable, Responsable, Serializabl
         $this->config->unlock(...$properties);
     }
 
+    public function isLocked(string $property): bool
+    {
+        return in_array($property, $this->getLockedProperties());
+    }
+
+    public function isUnlocked(string $property): bool
+    {
+        return ! $this->isLocked($property);
+    }
+
     public function getLockedProperties(): array
     {
         $this->ensureConfigIsLoaded();

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -618,6 +618,27 @@ class SettingsTest extends TestCase
         $this->assertEquals(['name'], $settings->getLockedProperties());
     }
 
+    public function it_can_check_if_a_setting_is_locked_or_unlocked()
+    {
+        $this->migrateDummySimpleSettings();
+
+        /** @var \Spatie\LaravelSettings\Tests\TestClasses\DummySimpleSettings $settings */
+        $settings = resolve(DummySimpleSettings::class);
+
+        $this->assertEmpty($settings->getLockedProperties());
+
+        $repository = $settings->getRepository();
+
+        $repository->lockProperties('dummy_simple', ['name']);
+
+        $settings->refresh();
+
+        $this->assertEquals(['name'], $settings->getLockedProperties());
+
+        $this->assertEquals(true, $settings->isLocked('name'));
+        $this->assertEquals(false, $settings->isUnlocked('name'));
+    }
+
     /** @test */
     public function it_can_check_if_a_property_has_been_set_if_properties_are_not_loaded()
     {


### PR DESCRIPTION
I came into the situation where I wanted to check if a setting was locked, without fetching all the locked settings and filter them afterwards myself.

This pull request makes this possible with the `isLocked()` and `isUnlocked()` method.

Hope this helps!