### PR TITLE
Add PHP 8.1 Support

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -3,27 +3,21 @@ name: Check & fix styling
 on: [push]
 
 jobs:
-    style:
-        runs-on: ubuntu-latest
+  php-cs-fixer:
+    runs-on: ubuntu-latest
 
-        steps:
-            -   name: Checkout code
-                uses: actions/checkout@v1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
 
-            -   name: Fix style
-                uses: docker://oskarstark/php-cs-fixer-ga
-                with:
-                    args: --config=.php_cs.dist.php --allow-risky=yes
+      - name: Run PHP CS Fixer
+        uses: docker://oskarstark/php-cs-fixer-ga
+        with:
+          args: --config=.php_cs.dist.php --allow-risky=yes
 
-            -   name: Extract branch name
-                shell: bash
-                run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-                id: extract_branch
-
-            -   name: Commit changes
-                uses: stefanzweifel/git-auto-commit-action@v2.3.0
-                with:
-                    commit_message: Fix styling
-                    branch: ${{ steps.extract_branch.outputs.branch }}
-                env:
-                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Fix styling

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [7.4, 8.0]
+        php: [ 8.1, 8.0, 7.4 ]
         laravel: [ 7.*, 8.* ]
         dependency-version: [ prefer-stable ]
         include:
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,13 +18,11 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php: [ 8.1, 8.0, 7.4 ]
-        laravel: [ 7.*, 8.* ]
+        laravel: [ 8.* ]
         dependency-version: [ prefer-stable ]
         include:
-          - laravel: 7.*
-            testbench: 5.*
           - laravel: 8.*
-            testbench: 6.*
+            testbench: ^6.23
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
@@ -42,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,28 @@
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md

--- a/composer.json
+++ b/composer.json
@@ -18,20 +18,20 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "illuminate/database": "^7.0|^8.24.0",
-        "doctrine/dbal" : "^2.6|^3",
-        "phpdocumentor/type-resolver": "^1.4",
-        "spatie/data-transfer-object": "^2.0|^3.0",
-        "spatie/temporary-directory": "^1.2|^2.0"
+        "illuminate/database": "^7.0|^8.73",
+        "doctrine/dbal": "^2.13|^3.2",
+        "phpdocumentor/type-resolver": "^1.5",
+        "spatie/data-transfer-object": "^2.8|^3.7",
+        "spatie/temporary-directory": "^1.3|^2.0"
     },
     "require-dev": {
         "ext-redis": "*",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^5.0|^6.0",
-        "phpunit/phpunit": "^9.1",
-        "psalm/plugin-laravel": "^1.4",
+        "orchestra/testbench": "^5.0|^6.23",
+        "phpunit/phpunit": "^9.5",
+        "psalm/plugin-laravel": "^1.5",
         "spatie/phpunit-snapshot-assertions": "^4.2",
-        "vimeo/psalm": "^4.2"
+        "vimeo/psalm": "^4.13"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "illuminate/database": "^7.0|^8.73",
+        "illuminate/database": "^8.73",
         "doctrine/dbal": "^2.13|^3.2",
         "phpdocumentor/type-resolver": "^1.5",
         "spatie/data-transfer-object": "^2.8|^3.7",
@@ -27,7 +27,7 @@
     "require-dev": {
         "ext-redis": "*",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^5.0|^6.23",
+        "orchestra/testbench": "^6.23",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-laravel": "^1.5",
         "spatie/phpunit-snapshot-assertions": "^4.2",


### PR DESCRIPTION
This PR adds PHP 8.1 support to the tests workflow.

Additionally, it:
- **drops support for Laravel 7.x**
- bumps dependency versions to latest in `composer.json`
- adds the update changelog workflow
- bumps github action versions where appropriate

_This repository needs its primary branch renamed from `master` to `main`._