### PR TITLE
Added default nullable column to migrator

### DIFF
--- a/src/Migrations/SettingsBlueprint.php
+++ b/src/Migrations/SettingsBlueprint.php
@@ -25,7 +25,7 @@ class SettingsBlueprint
         );
     }
 
-    public function add(string $name, $value, bool $encrypted = false): void
+    public function add(string $name, mixed $value = null, bool $encrypted = false): void
     {
         $this->migrator->add($this->prependWithGroup($name), $value, $encrypted);
     }
@@ -40,7 +40,7 @@ class SettingsBlueprint
         $this->migrator->update($this->prependWithGroup($name), $closure, $encrypted);
     }
 
-    public function addEncrypted(string $name, $value): void
+    public function addEncrypted(string $name, mixed $value = null): void
     {
         $this->migrator->addEncrypted($this->prependWithGroup($name), $value);
     }

--- a/src/Migrations/SettingsBlueprint.php
+++ b/src/Migrations/SettingsBlueprint.php
@@ -25,7 +25,7 @@ class SettingsBlueprint
         );
     }
 
-    public function add(string $name, mixed $value = null, bool $encrypted = false): void
+    public function add(string $name, $value = null, bool $encrypted = false): void
     {
         $this->migrator->add($this->prependWithGroup($name), $value, $encrypted);
     }
@@ -40,7 +40,7 @@ class SettingsBlueprint
         $this->migrator->update($this->prependWithGroup($name), $closure, $encrypted);
     }
 
-    public function addEncrypted(string $name, mixed $value = null): void
+    public function addEncrypted(string $name, $value = null): void
     {
         $this->migrator->addEncrypted($this->prependWithGroup($name), $value);
     }

--- a/src/Migrations/SettingsMigrator.php
+++ b/src/Migrations/SettingsMigrator.php
@@ -48,7 +48,7 @@ class SettingsMigrator
         $this->deleteProperty($from);
     }
 
-    public function add(string $property, mixed $value = null, bool $encrypted = false): void
+    public function add(string $property, $value = null, bool $encrypted = false): void
     {
         if ($this->checkIfPropertyExists($property)) {
             throw SettingAlreadyExists::whenAdding($property);
@@ -87,7 +87,7 @@ class SettingsMigrator
         $this->updatePropertyPayload($property, $updatedPayload);
     }
 
-    public function addEncrypted(string $property, mixed $value = null): void
+    public function addEncrypted(string $property, $value = null): void
     {
         $this->add($property, $value, true);
     }

--- a/src/Migrations/SettingsMigrator.php
+++ b/src/Migrations/SettingsMigrator.php
@@ -48,7 +48,7 @@ class SettingsMigrator
         $this->deleteProperty($from);
     }
 
-    public function add(string $property, $value, bool $encrypted = false): void
+    public function add(string $property, mixed $value = null, bool $encrypted = false): void
     {
         if ($this->checkIfPropertyExists($property)) {
             throw SettingAlreadyExists::whenAdding($property);
@@ -87,7 +87,7 @@ class SettingsMigrator
         $this->updatePropertyPayload($property, $updatedPayload);
     }
 
-    public function addEncrypted(string $property, $value): void
+    public function addEncrypted(string $property, mixed $value = null): void
     {
         $this->add($property, $value, true);
     }


### PR DESCRIPTION
With this PR we can now leave out the second param when creating migrations (it defaults to `null`).

```php
$this->migrator->add('app_name'); // it's the same as $this->migrator->add('app_name', null);

// and in migrator blueprint also
$blueprint->add('app_name');
```

I've also ajdusted `encrypted` counterparts.