### PR TITLE
Switch to using scoped instances instead of singletons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,11 @@
         "test-coverage": "vendor/bin/pest --coverage"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true,
+            "phpstan/extension-installer": true
+        }
     },
     "extra": {
         "laravel": {

--- a/src/LaravelSettingsServiceProvider.php
+++ b/src/LaravelSettingsServiceProvider.php
@@ -57,7 +57,7 @@ class LaravelSettingsServiceProvider extends ServiceProvider
             config('settings.cache.ttl')
         ));
 
-        $this->app->singleton(SettingsMapper::class);
+        $this->app->scoped(SettingsMapper::class);
 
         $settingsContainer = app(SettingsContainer::class);
         $settingsContainer->registerBindings();

--- a/src/SettingsContainer.php
+++ b/src/SettingsContainer.php
@@ -25,7 +25,7 @@ class SettingsContainer
         $cache = $this->container->make(SettingsCache::class);
 
         $this->getSettingClasses()->each(function (string $settingClass) use ($cache) {
-            $this->container->singleton($settingClass, function () use ($cache, $settingClass) {
+            $this->container->scoped($settingClass, function () use ($cache, $settingClass) {
                 if ($cache->has($settingClass)) {
                     try {
                         return $cache->get($settingClass);


### PR DESCRIPTION
Using singletons for settings classes can cause the settings instance to remain in the IOC container over multiple jobs (Horizon) or multiple requests (Octane). This isn't an issue for most projects, as settings don't randomly change every request. However, in a multi-tenancy environment the loaded settings different every job and every request, based on the tenant. In this case we do not want to re-use a settings instance that's still around in the IOC container from the previous request.

TL;DR: switching `singleton` to `scoped` causes the settings class instances to be refreshed every request & every job

https://laravel.com/docs/8.x/container#binding-scoped