### PR TITLE
Leave this array empty to disable auto discovery

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -69,7 +69,7 @@ return [
      * register them.
      */
     'auto_discover_settings' => [
-        app()->path(),
+        // app()->path(),
     ],
 
     /*


### PR DESCRIPTION
This prevents breaking artisan out of the box.

See https://github.com/spatie/laravel-settings/issues/131