### PR TITLE
Remove deprecated package

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require spatie/data-transfer-object --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-settings` will be documented in this file
 
+# Unreleased
+
+- Make `spatie/data-transfer-object` dependency optional. (#160)
+
 ## 2.4.5 - 2022-09-28
 
 - Add deleteIfExists() method to migrator (#154)

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "illuminate/database": "^8.73|^9.0",
         "doctrine/dbal": "^2.13|^3.2",
         "phpdocumentor/type-resolver": "^1.5",
-        "spatie/data-transfer-object": "^2.8|^3.7",
         "spatie/temporary-directory": "^1.3|^2.0"
     },
     "require-dev": {
@@ -37,6 +36,9 @@
         "phpunit/phpunit": "^9.5",
         "spatie/pest-plugin-snapshots": "^1.1",
         "spatie/phpunit-snapshot-assertions": "^4.2"
+    },
+    "suggest": {
+        "spatie/data-transfer-object": "Allows for DTO casting to settings. (deprecated)"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Had some time this morning to create a pull request for the issue I've created yesterday. I think this is the easiest way to go because the dto package is not really required as a root dependency. I've made it optional so people can still use it.

We could also completely remove the dependency but that would be a pretty big breaking change.

Closes #160 