### PR TITLE
add dynamic group prefixer

### DIFF
--- a/src/LaravelSettingsServiceProvider.php
+++ b/src/LaravelSettingsServiceProvider.php
@@ -58,6 +58,7 @@ class LaravelSettingsServiceProvider extends ServiceProvider
         ));
 
         $this->app->scoped(SettingsMapper::class);
+        $this->app->scoped(SettingsGroupPrefixer::class);
 
         $settingsContainer = app(SettingsContainer::class);
         $settingsContainer->registerBindings();

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -153,6 +153,18 @@ abstract class Settings implements Arrayable, Jsonable, Responsable
         $this->loadValues($data);
     }
 
+
+    /**
+     * @param  string  $prefix
+     * @return $this
+     */
+    public function setGroupPrefixer(string $prefix): self
+    {
+        app(SettingsGroupPrefixer::class)->setPrefix($prefix);
+
+        return $this->refresh();
+    }
+
     /**
      * @param \Illuminate\Support\Collection|array $properties
      *

--- a/src/SettingsConfig.php
+++ b/src/SettingsConfig.php
@@ -70,7 +70,7 @@ class SettingsConfig
 
     public function getGroup(): string
     {
-        return $this->settingsClass::group();
+        return app(SettingsGroupPrefixer::class)->getPrefix().$this->settingsClass::group();
     }
 
     public function isEncrypted(string $name): bool

--- a/src/SettingsGroupPrefixer.php
+++ b/src/SettingsGroupPrefixer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\LaravelSettings;
+
+class SettingsGroupPrefixer
+{
+    private string $prefix = '';
+
+    /**
+     * @return string
+     */
+    public function getPrefix(): string
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * @param  string  $prefix
+     */
+    public function setPrefix(string $prefix): void
+    {
+        $this->prefix = $prefix;
+    }
+}

--- a/tests/SettingsGroupPrefixerTest.php
+++ b/tests/SettingsGroupPrefixerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\LaravelSettings\Tests;
+
+use Spatie\LaravelSettings\Tests\TestClasses\DummySimpleSettings;
+
+it('can add a prefix to group name', function() {
+    $this->migrateDummySimpleSettings();
+    $this->migrateDummyGroupPrefixSettings();
+
+    $settings = resolve(DummySimpleSettings::class);
+    expect($settings)
+        ->name->toEqual('Louis Armstrong')
+        ->description->toEqual('Hello Dolly');
+
+    $settings->setGroupPrefixer('some_id:');
+    expect($settings)
+        ->name->toEqual('John Doe')
+        ->description->toEqual('John, Again?');
+
+    $settings->setGroupPrefixer('');
+    expect($settings)
+        ->name->toEqual('Louis Armstrong')
+        ->description->toEqual('Hello Dolly');
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -62,6 +62,18 @@ class TestCase extends BaseTestCase
         return $this;
     }
 
+    protected function migrateDummyGroupPrefixSettings(
+        string $name = 'John Doe',
+        string $description = 'John, Again?'
+    ): self {
+        resolve(SettingsMigrator::class)->inGroup('some_id:dummy_simple', function (SettingsBlueprint $blueprint) use ($description, $name): void {
+            $blueprint->add('name', $name);
+            $blueprint->add('description', $description);
+        });
+
+        return $this;
+    }
+
     protected function migrateDummySettings(CarbonImmutable $date): self
     {
         resolve(SettingsMigrator::class)->inGroup('dummy', function (SettingsBlueprint $blueprint) use ($date): void {


### PR DESCRIPTION
Hi,

I have added a prefix for group names. It is useful when separating some settings by models.

For example, lets say we have a multi domain project. Each domain will have its own custom general settings. 
Or maybe we have multiple mail settings that we wanna select the corresponding settings from database. 

lets say a model's id is 27.

```php 
   // AppServiceProvider
    public function boot()
    {
        app(GeneralSettings::class)->setGroupPrefixer('27:');
    }
```

Then the settings come from the group : "27:general " . 

I kept the changes as minimal as possible so not to break anything. It may be useful to others so I'll leave it here.

