### PR TITLE
Create new Setting Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ return [
     ],
 
     /*
+     * The path where the settings classes will be created.
+     */
+    'setting_class_path' => app_path('Settings'),
+
+    /*
      * In these directories settings migrations will be stored and ran when migrating. A settings 
      * migration created via the make:settings-migration command will be stored in the first path or
      * a custom defined path when running the command.
@@ -195,6 +200,12 @@ class GeneralSettings extends Settings
         return 'general';
     }
 }
+```
+
+You can generate a new settings class using this artisan command. Before you do, please check if the `setting_class_path` is correctly set. You can also specify a `path` option, which is optional.
+
+```bash
+    php artisan make:setting SettingName --group=groupName 
 ```
 
 Now, you will have to add this settings class to the `settings.php` config file in the `settings` array so it can be loaded by Laravel:

--- a/config/settings.php
+++ b/config/settings.php
@@ -11,6 +11,11 @@ return [
     ],
 
     /*
+     * The path where the settings classes will be created.
+     */
+    'setting_class_path' => app_path('Settings'),
+
+    /*
      * In these directories settings migrations will be stored and ran when migrating. A settings
      * migration created via the make:settings-migration command will be stored in the first path or
      * a custom defined path when running the command.

--- a/src/Console/MakeSettingCommand.php
+++ b/src/Console/MakeSettingCommand.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelSettings\Console;
 
+use InvalidArgumentException;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 
@@ -59,8 +60,6 @@ class MakeSettingCommand extends Command
             $this->getPath($name, $path),
             $this->getContent($name, $group, $path)
         );
-
-        $this->components->info(sprintf('%s created successfully.', $name));
     }
 
     protected function getStub(): string
@@ -95,9 +94,7 @@ EOT;
     protected function ensureSettingClassDoesntAlreadyExist($name, $path): void
     {
         if ($this->files->exists($this->getPath($name, $path))) {
-            $this->components->error(sprintf('%s already exists!', $name));
-
-            exit(1); // for some reason, return false was not working
+            throw new InvalidArgumentException(sprintf('%s already exists!', $name));
         }
     }
 

--- a/src/Console/MakeSettingCommand.php
+++ b/src/Console/MakeSettingCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Spatie\LaravelSettings\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use InvalidArgumentException;
+
+class MakeSettingCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:setting {name : The name of the setting class} {--group=default : The group name} {path? : Path to write the setting class file to}';
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+
+    protected $name = 'make:setting';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Settings Class';
+
+    /**
+     * @var Filesystem $files
+     */
+    protected Filesystem $files;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    public function handle()
+    {
+        $name = trim($this->input->getArgument('name'));
+
+        if (empty($name)) {
+            $this->error('The Setting Class name is required.');
+        }
+
+        $group = trim($this->input->getOption('group'));
+        $path = trim($this->input->getArgument('path'));
+
+        if (empty($path)) {
+            $path = $this->resolveSettingsPath();
+        }
+
+        $this->ensureSettingClassDoesntAlreadyExist($name, $path);
+
+        $this->files->put(
+            $this->getPath($name, $path),
+            $this->getContent($name, $group, $path)
+        );
+    }
+
+    protected function getStub(): string
+    {
+        return <<<EOT
+<?php
+
+{{ namespace }}
+
+use Spatie\LaravelSettings\Settings;
+
+class {{ class }} extends Settings
+{
+
+    public static function group(): string
+    {
+        return '{{ group }}';
+    }
+}
+EOT;
+    }
+
+    protected function getContent($name, $group, $path)
+    {
+        return str_replace(
+            ['{{ namespace }}', '{{ class }}', '{{ group }}'],
+            [$this->getNamespace($path), $name, $group],
+            $this->getStub()
+        );
+    }
+
+    protected function ensureSettingClassDoesntAlreadyExist($name, $path)
+    {
+        if ($this->files->exists($this->getPath($name, $path))) {
+            throw new InvalidArgumentException("Setting Class {$name} already exists!");
+        }
+    }
+
+    protected function resolveSettingsPath(): string
+    {
+        return config('settings.settings_path', app_path('Settings'));
+    }
+
+    protected function getPath($name, $path): string
+    {
+        return $path() . '/' . $name . '.php';
+    }
+
+    protected function getNamespace($path): string
+    {
+        return 'namespace' . ' ' . trim(implode('\\', array_map('ucfirst', explode('/', $path))), '\\') . ';';
+    }
+}

--- a/src/Console/MakeSettingCommand.php
+++ b/src/Console/MakeSettingCommand.php
@@ -59,6 +59,8 @@ class MakeSettingCommand extends Command
 
         $this->ensureSettingClassDoesntAlreadyExist($name, $path);
 
+        $this->files->ensureDirectoryExists($path);
+
         $this->files->put(
             $this->getPath($name, $path),
             $this->getContent($name, $group, $path)

--- a/src/Console/MakeSettingCommand.php
+++ b/src/Console/MakeSettingCommand.php
@@ -108,7 +108,7 @@ EOT;
 
     protected function getPath($name, $path): string
     {
-        return $path() . '/' . $name . '.php';
+        return $path . '/' . $name . '.php';
     }
 
     protected function getNamespace($path): string

--- a/src/LaravelSettingsServiceProvider.php
+++ b/src/LaravelSettingsServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\ServiceProvider;
 use Spatie\LaravelSettings\Console\CacheDiscoveredSettingsCommand;
 use Spatie\LaravelSettings\Console\ClearCachedSettingsCommand;
 use Spatie\LaravelSettings\Console\ClearDiscoveredSettingsCacheCommand;
+use Spatie\LaravelSettings\Console\MakeSettingCommand;
 use Spatie\LaravelSettings\Console\MakeSettingsMigrationCommand;
 use Spatie\LaravelSettings\Factories\SettingsRepositoryFactory;
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
@@ -32,6 +33,7 @@ class LaravelSettingsServiceProvider extends ServiceProvider
             }
 
             $this->commands([
+                MakeSettingCommand::class,
                 MakeSettingsMigrationCommand::class,
                 CacheDiscoveredSettingsCommand::class,
                 ClearDiscoveredSettingsCacheCommand::class,

--- a/tests/Console/MakeSettingCommandTest.php
+++ b/tests/Console/MakeSettingCommandTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\LaravelSettings\Tests\Console;
+
+it('creates a new test settings class on specified path', function () {
+    $tmpDir = sys_get_temp_dir();
+
+    $this->artisan('make:setting', [
+        'name' => 'TestSetting',
+        '--path' => $tmpDir,
+    ])->assertSuccessful();
+
+    $tmpList = glob(sprintf('%s/TestSetting.php', $tmpDir));
+
+    expect($tmpList)->toHaveCount(1);
+
+    // Remove test file.
+    unlink($tmpList[0]);
+});


### PR DESCRIPTION
Well, I'm too lazy to create a new class whenever I need to add a new group of settings😂😂. This feature was first introduced by @egyjs in #126. But because of inactivity, it was closed without being merged. 

This PR adds a new `make:setting` command, that is functional and its test included.