### PR TITLE
Update MakeSettingCommand.php

### DIFF
--- a/src/Console/MakeSettingCommand.php
+++ b/src/Console/MakeSettingCommand.php
@@ -110,7 +110,7 @@ EOT;
 
     protected function getNamespace($path): string
     {
-        $namespace = str_replace('/', '\\', trim(str_replace(base_path(), '', $path), '/')) . ';';
+        $namespace = str_replace('/', '\\', trim(str_replace(ucfirst(base_path()), '', $path), '/')) . ';';
 
         return "namespace $namespace";
     }


### PR DESCRIPTION
When generating a new settings class the default `app_path()` helper makes the `app` lowercase and should be `capitalized`.

This makes ide highlights the namespace.