### PR TITLE
Follow Laravel's namespace convention in MakeSettingCommand.php

### DIFF
--- a/src/Console/MakeSettingCommand.php
+++ b/src/Console/MakeSettingCommand.php
@@ -67,7 +67,7 @@ class MakeSettingCommand extends Command
         return <<<EOT
 <?php
 
-{{ namespace }}
+namespace {{ namespace }};
 
 use Spatie\LaravelSettings\Settings;
 
@@ -100,7 +100,7 @@ EOT;
 
     protected function resolveSettingsPath(): string
     {
-        return config('settings.settings_path', app_path('Settings'));
+        return config('settings.setting_class_path', app_path('Settings'));
     }
 
     protected function getPath($name, $path): string
@@ -110,8 +110,8 @@ EOT;
 
     protected function getNamespace($path): string
     {
-        $namespace = str_replace('/', '\\', trim(str_replace(ucfirst(base_path()), '', $path), '/')) . ';';
+        $path = trim(str_replace([base_path(), '/'], ['', '\\'], $path), '\\');
 
-        return "namespace $namespace";
+        return implode('\\', array_map(fn ($directory) => ucfirst($directory), explode('\\', $path)));
     }
 }


### PR DESCRIPTION
1. I've updated `MakeSettingCommand::getNamespace` to follow Laravel's namespace convention. All namespace names within the hierarchy will be capitalized.
2. `MakeSettingCommand::getNamespace` will now return the namespace alone, rather than returning the full line of code intended for the final file. The stub has been edited to take care of the surrounding code, which is how Laravel handles inserting the namespace in its generator commands.
3. `MakeSettingCommand::resolveSettingsPath` will now reference the correct config option: `settings.setting_class_path`.