### PR TITLE
Show message and target path after setting migration created

### DIFF
--- a/src/Console/MakeSettingsMigrationCommand.php
+++ b/src/Console/MakeSettingsMigrationCommand.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelSettings\Console;
 
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
@@ -79,7 +80,7 @@ EOT;
 
     protected function getPath($name, $path): string
     {
-        return $path . '/' . date('Y_m_d_His') . '_' . Str::snake($name) . '.php';
+        return $path . '/' . Carbon::now()->format('Y_m_d_His') . '_' . Str::snake($name) . '.php';
     }
 
     protected function resolveMigrationPaths(): array

--- a/src/Console/MakeSettingsMigrationCommand.php
+++ b/src/Console/MakeSettingsMigrationCommand.php
@@ -37,9 +37,11 @@ class MakeSettingsMigrationCommand extends Command
         $this->files->ensureDirectoryExists($path);
 
         $this->files->put(
-            $this->getPath($name, $path),
+            $file =$this->getPath($name, $path),
             str_replace('{{ class }}', $name, $this->getStub())
         );
+
+        $this->info(sprintf('Setting migration [%s] created successfully.', $file));
     }
 
     protected function getStub(): string

--- a/tests/Console/MakeSettingsMigrationCommandTest.php
+++ b/tests/Console/MakeSettingsMigrationCommandTest.php
@@ -2,15 +2,19 @@
 
 namespace Spatie\LaravelSettings\Tests\Console;
 
-use function Orchestra\Testbench\artisan;
+use Carbon\Carbon;
 
 it('creates a new test settings migration on specified path', function () {
     $tmpDir = sys_get_temp_dir();
-    
-    artisan($this, 'make:settings-migration', [
+
+    Carbon::setTestNow(Carbon::create(2023, 2, 22, 12, 0, 0));
+
+    $this->artisan('make:settings-migration', [
         'name' => 'CreateNewTestSettingsMigration',
         'path' => $tmpDir,
-    ]);
+    ])
+        ->expectsOutput(sprintf('Setting migration [%s/2023_02_22_120000_create_new_test_settings_migration.php] created successfully.', $tmpDir))
+        ->assertExitCode(0);
 
     $tmpList = glob(sprintf('%s/*_create_new_test_settings_migration.php', $tmpDir));
 


### PR DESCRIPTION
Previously, no message was displayed to the user after executing the ``make:settings-migration`` command, but now, after executing the command, a message including the result and the location of the created file is displayed to the user.