### PR TITLE
Introduce new batch update for settings reduces the number of queries sent to the database and redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1026,9 +1026,9 @@ interface SettingsRepository
     public function createProperty(string $group, string $name, $payload): void;
 
     /**
-     * Update the payload of a property within a group
+     * Update the payloads of properties within a group.
      */
-    public function updatePropertyPayload(string $group, string $name, $value): void;
+    public function updatePropertiesPayload(string $group, array $properties): void;
 
     /**
      * Delete a property from a group

--- a/database/migrations/create_settings_table.php.stub
+++ b/database/migrations/create_settings_table.php.stub
@@ -13,10 +13,12 @@ return new class extends Migration
 
             $table->string('group')->index();
             $table->string('name');
-            $table->boolean('locked');
+            $table->boolean('locked')->default(false);
             $table->json('payload');
 
             $table->timestamps();
+
+            $table->unique(['group', 'name']);
         });
     }
 

--- a/src/Migrations/SettingsMigrator.php
+++ b/src/Migrations/SettingsMigrator.php
@@ -76,7 +76,7 @@ class SettingsMigrator
             $this->deleteProperty($property);
         }
     }
-    
+
     public function update(string $property, Closure $closure, bool $encrypted = false): void
     {
         if (! $this->checkIfPropertyExists($property)) {
@@ -165,7 +165,7 @@ class SettingsMigrator
             $payload = optional($this->getCast($group, $name))->set($payload) ?: $payload;
         }
 
-        $this->repository->updatePropertyPayload($group, $name, $payload);
+        $this->repository->updatePropertiesPayload($group, [$name => $payload]);
     }
 
     protected function deleteProperty(string $property): void

--- a/src/SettingsRepositories/RedisSettingsRepository.php
+++ b/src/SettingsRepositories/RedisSettingsRepository.php
@@ -3,7 +3,6 @@
 namespace Spatie\LaravelSettings\SettingsRepositories;
 
 use Illuminate\Redis\RedisManager;
-use Illuminate\Support\Collection;
 
 class RedisSettingsRepository implements SettingsRepository
 {
@@ -46,20 +45,13 @@ class RedisSettingsRepository implements SettingsRepository
         $this->connection->hSet($this->prefix . $group, $name, json_encode($payload));
     }
 
-    public function updatePropertyPayload(string $group, string $name, $value): void
+    public function updatePropertiesPayload(string $group, array $properties): void
     {
-        $this->connection->hSet($this->prefix . $group, $name, json_encode($value));
-    }
+        $properties = collect($properties)->mapWithKeys(function ($payload, $name) use ($group) {
+            return [$name => json_encode($payload)];
+        })->toArray();
 
-    public function updatePropertiesPayload(string $group, Collection $properties): void
-    {
-        $data = [];
-
-        $properties->each(function (array $property) use ($group, &$data) {
-            $data[data_get($property, 'name')] = json_encode(data_get($property, 'payload'));
-        });
-
-        $this->connection->hmset($this->prefix . $group, $data);
+        $this->connection->hmset($this->prefix . $group, $properties);
     }
 
     public function deleteProperty(string $group, string $name): void

--- a/src/SettingsRepositories/RedisSettingsRepository.php
+++ b/src/SettingsRepositories/RedisSettingsRepository.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelSettings\SettingsRepositories;
 
 use Illuminate\Redis\RedisManager;
+use Illuminate\Support\Collection;
 
 class RedisSettingsRepository implements SettingsRepository
 {
@@ -48,6 +49,13 @@ class RedisSettingsRepository implements SettingsRepository
     public function updatePropertyPayload(string $group, string $name, $value): void
     {
         $this->connection->hSet($this->prefix . $group, $name, json_encode($value));
+    }
+
+    public function updatePropertiesPayload(string $group, Collection $properties): void
+    {
+        $properties->each(function (array $property) use ($group) {
+            $this->connection->hSet($this->prefix . $group, data_get($property, 'name'), json_encode(data_get($property, 'payload')));
+        });
     }
 
     public function deleteProperty(string $group, string $name): void

--- a/src/SettingsRepositories/RedisSettingsRepository.php
+++ b/src/SettingsRepositories/RedisSettingsRepository.php
@@ -53,9 +53,13 @@ class RedisSettingsRepository implements SettingsRepository
 
     public function updatePropertiesPayload(string $group, Collection $properties): void
     {
-        $properties->each(function (array $property) use ($group) {
-            $this->connection->hSet($this->prefix . $group, data_get($property, 'name'), json_encode(data_get($property, 'payload')));
+        $data = [];
+
+        $properties->each(function (array $property) use ($group, &$data) {
+            $data[data_get($property, 'name')] = json_encode(data_get($property, 'payload'));
         });
+
+        $this->connection->hmset($this->prefix . $group, $data);
     }
 
     public function deleteProperty(string $group, string $name): void

--- a/src/SettingsRepositories/SettingsRepository.php
+++ b/src/SettingsRepositories/SettingsRepository.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\LaravelSettings\SettingsRepositories;
 
+use Illuminate\Support\Collection;
+
 interface SettingsRepository
 {
     /**
@@ -28,6 +30,11 @@ interface SettingsRepository
      * Update the payload of a property within a group
      */
     public function updatePropertyPayload(string $group, string $name, $value): void;
+
+    /**
+     * Update the payload of a property within a group
+     */
+    public function updatePropertiesPayload(string $group, Collection $properties): void;
 
     /**
      * Delete a property from a group

--- a/src/SettingsRepositories/SettingsRepository.php
+++ b/src/SettingsRepositories/SettingsRepository.php
@@ -2,8 +2,6 @@
 
 namespace Spatie\LaravelSettings\SettingsRepositories;
 
-use Illuminate\Support\Collection;
-
 interface SettingsRepository
 {
     /**
@@ -27,14 +25,9 @@ interface SettingsRepository
     public function createProperty(string $group, string $name, $payload): void;
 
     /**
-     * Update the payload of a property within a group
+     * Update the payloads of properties within a group.
      */
-    public function updatePropertyPayload(string $group, string $name, $value): void;
-
-    /**
-     * Update the payload of a property within a group
-     */
-    public function updatePropertiesPayload(string $group, Collection $properties): void;
+    public function updatePropertiesPayload(string $group, array $properties): void;
 
     /**
      * Delete a property from a group

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -43,10 +43,12 @@ function prepareOtherConnection(): void
 
         $table->string('group')->index();
         $table->string('name');
-        $table->boolean('locked');
+        $table->boolean('locked')->default(false);
         $table->json('payload');
 
         $table->timestamps();
+
+        $table->unique(['group', 'name']);
     });
 }
 

--- a/tests/SettingsRepositories/DatabaseSettingsRepositoryTest.php
+++ b/tests/SettingsRepositories/DatabaseSettingsRepositoryTest.php
@@ -124,11 +124,13 @@ it('can update a property payload', function () {
     $this->repository->createProperty('test', 'd', null);
     $this->repository->createProperty('test', 'e', 42);
 
-    $this->repository->updatePropertyPayload('test', 'a', null);
-    $this->repository->updatePropertyPayload('test', 'b', false);
-    $this->repository->updatePropertyPayload('test', 'c', ['light', 'dark']);
-    $this->repository->updatePropertyPayload('test', 'd', 'Alpha');
-    $this->repository->updatePropertyPayload('test', 'e', 69);
+    $this->repository->updatePropertiesPayload('test', [
+        'a' => null,
+        'b' => false,
+        'c' => ['light', 'dark'],
+        'd' => 'Alpha',
+        'e' => 69,
+    ]);
 
     expect($this->repository->getPropertyPayload('test', 'a'))->toBeNull();
     expect($this->repository->getPropertyPayload('test', 'b'))->toBeFalse();
@@ -208,7 +210,7 @@ it('can have different configuration options', function ($repositoryFactory) {
     expect($otherRepository->getPropertiesInGroup('test'))->toEqual(['a' => 'Alpha']);
 
     $otherRepository->createProperty('test', 'b', 'Beta');
-    $otherRepository->updatePropertyPayload('test', 'b', 'Beta updated');
+    $otherRepository->updatePropertiesPayload('test', ['b' => 'Beta updated']);
 
     expect($otherRepository->getPropertyPayload('test', 'b'))->toEqual('Beta updated');
 

--- a/tests/SettingsRepositories/DatabaseSettingsRepositoryTest.php
+++ b/tests/SettingsRepositories/DatabaseSettingsRepositoryTest.php
@@ -234,10 +234,12 @@ it('can have a different table name', function () {
 
         $table->string('group')->index();
         $table->string('name');
-        $table->boolean('locked');
+        $table->boolean('locked')->default(false);
         $table->json('payload');
 
         $table->timestamps();
+
+        $table->unique(['group', 'name']);
     });
 
     $repository = new DatabaseSettingsRepository([

--- a/tests/SettingsRepositories/RedisSettingsRepositoryTest.php
+++ b/tests/SettingsRepositories/RedisSettingsRepositoryTest.php
@@ -113,14 +113,14 @@ it('can update a property payload', function () {
 
 
 it('can update a properties payload', function () {
-    $this->repository->createProperty('test', 'a', 'Alpha');
-    $this->repository->createProperty('test', 'b', true);
-    $this->repository->createProperty('test', 'c', ['night', 'day']);
-    $this->repository->createProperty('test', 'd', null);
-    $this->repository->createProperty('test', 'e', 42);
-    $this->repository->createProperty('second_test', 'a', ['night', 'day']);
-    $this->repository->createProperty('second_test', 'b', null);
-    $this->repository->createProperty('second_test', 'c', 42);
+    $this->repository->createProperty('test1', 'a', 'Alpha');
+    $this->repository->createProperty('test1', 'b', true);
+    $this->repository->createProperty('test1', 'c', ['night', 'day']);
+    $this->repository->createProperty('test1', 'd', null);
+    $this->repository->createProperty('test1', 'e', 42);
+    $this->repository->createProperty('test2', 'a', ['night', 'day']);
+    $this->repository->createProperty('test2', 'b', null);
+    $this->repository->createProperty('test2', 'c', 42);
 
     $data = [
         ['group' => 'test1', 'name' => 'a', 'payload' => null],

--- a/tests/SettingsRepositories/RedisSettingsRepositoryTest.php
+++ b/tests/SettingsRepositories/RedisSettingsRepositoryTest.php
@@ -3,7 +3,6 @@
 namespace Spatie\LaravelSettings\Tests\SettingsRepositories;
 
 use Illuminate\Redis\RedisManager;
-use Illuminate\Support\Collection;
 use function PHPUnit\Framework\assertEqualsCanonicalizing;
 
 use Spatie\LaravelSettings\SettingsRepositories\RedisSettingsRepository;
@@ -98,11 +97,15 @@ it('can update a property payload', function () {
     $this->repository->createProperty('test', 'd', null);
     $this->repository->createProperty('test', 'e', 42);
 
-    $this->repository->updatePropertyPayload('test', 'a', null);
-    $this->repository->updatePropertyPayload('test', 'b', false);
-    $this->repository->updatePropertyPayload('test', 'c', ['light', 'dark']);
-    $this->repository->updatePropertyPayload('test', 'd', 'Alpha');
-    $this->repository->updatePropertyPayload('test', 'e', 69);
+    $newValues = [
+        'a' => null,
+        'b' => false,
+        'c' => ['light', 'dark'],
+        'd' => 'Alpha',
+        'e' => 69,
+    ];
+
+    $this->repository->updatePropertiesPayload('test', $newValues);
 
     expect($this->repository->getPropertyPayload('test', 'a'))->toBeNull();
     expect($this->repository->getPropertyPayload('test', 'b'))->toBeFalse();
@@ -113,38 +116,27 @@ it('can update a property payload', function () {
 
 
 it('can update a properties payload', function () {
-    $this->repository->createProperty('test1', 'a', 'Alpha');
-    $this->repository->createProperty('test1', 'b', true);
-    $this->repository->createProperty('test1', 'c', ['night', 'day']);
-    $this->repository->createProperty('test1', 'd', null);
-    $this->repository->createProperty('test1', 'e', 42);
-    $this->repository->createProperty('test2', 'a', ['night', 'day']);
-    $this->repository->createProperty('test2', 'b', null);
-    $this->repository->createProperty('test2', 'c', 42);
+    $this->repository->createProperty('test', 'a', 'Alpha');
+    $this->repository->createProperty('test', 'b', true);
+    $this->repository->createProperty('test', 'c', ['night', 'day']);
+    $this->repository->createProperty('test', 'd', null);
+    $this->repository->createProperty('test', 'e', 42);
 
-    $data = [
-        ['group' => 'test1', 'name' => 'a', 'payload' => null],
-        ['group' => 'test1', 'name' => 'b', 'payload' => false],
-        ['group' => 'test1', 'name' => 'c', 'payload' => ['light', 'dark']],
-        ['group' => 'test1', 'name' => 'd', 'payload' => 'Alpha'],
-        ['group' => 'test1', 'name' => 'e', 'payload' => 69],
-        ['group' => 'test2', 'name' => 'a', 'payload' => 'Alpha'],
-        ['group' => 'test2', 'name' => 'b', 'payload' => 'beta'],
-        ['group' => 'test2', 'name' => 'c', 'payload' => 87],
+    $properties = [
+        'a' => null,
+        'b' => false,
+        'c' => ['light', 'dark'],
+        'd' => 'Alpha',
+        'e' => 69,
     ];
 
-    collect($data)->groupBy('group')->each(function (Collection $properties, string $group) {
-        $this->repository->updatePropertiesPayload($group, $properties);
-    });
+    $this->repository->updatePropertiesPayload('test', $properties);
 
-    expect($this->repository->getPropertyPayload('test1', 'a'))->toBeNull();
-    expect($this->repository->getPropertyPayload('test1', 'b'))->toBeFalse();
-    expect($this->repository->getPropertyPayload('test1', 'c'))->toEqual(['light', 'dark']);
-    expect($this->repository->getPropertyPayload('test1', 'd'))->toEqual('Alpha');
-    expect($this->repository->getPropertyPayload('test1', 'e'))->toEqual(69);
-    expect($this->repository->getPropertyPayload('test2', 'a'))->toEqual('Alpha');
-    expect($this->repository->getPropertyPayload('test2', 'b'))->toEqual('beta');
-    expect($this->repository->getPropertyPayload('test2', 'c'))->toEqual(87);
+    expect($this->repository->getPropertyPayload('test', 'a'))->toBeNull();
+    expect($this->repository->getPropertyPayload('test', 'b'))->toBeFalse();
+    expect($this->repository->getPropertyPayload('test', 'c'))->toEqual(['light', 'dark']);
+    expect($this->repository->getPropertyPayload('test', 'd'))->toEqual('Alpha');
+    expect($this->repository->getPropertyPayload('test', 'e'))->toEqual(69);
 });
 
 it('can delete a property', function () {
@@ -209,7 +201,7 @@ it('can use a prefix', function () {
 
     expect($this->repository->getPropertyPayload('test', 'a'))->toEqual('Alpha');
 
-    $this->repository->updatePropertyPayload('test', 'a', 'Alpha Updated');
+    $this->repository->updatePropertiesPayload('test', ['a' => 'Alpha Updated']);
 
     expect($this->client->hGet('spatie.test', 'a'))
         ->toEqual(json_encode('Alpha Updated'));

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -583,8 +583,8 @@ it('can refresh the settings properties', function () {
 
     $repository = $settings->getRepository();
 
-    $repository->updatePropertyPayload('dummy_simple', 'name', 'Rick Astley');
-    $repository->updatePropertyPayload('dummy_simple', 'description', 'Never gonna give you up');
+    $repository->updatePropertiesPayload('dummy_simple', ['name' => 'Rick Astley']);
+    $repository->updatePropertiesPayload('dummy_simple', ['description' => 'Never gonna give you up']);
 
     $settings->refresh();
 


### PR DESCRIPTION
The purpose of this pull request is to improve the performance of database updates discussed [here](https://github.com/spatie/laravel-settings/discussions/212), by grouping records by their respective groups and performing batch updates on each group. Instead of saving each record in a single query, this approach sends a single request per group, resulting in faster and more efficient updates at the database level.
It is safe to use this feature because it includes error handling that falls back to the original save logic in the event of any issues. This ensures that data is not lost and that the application can continue to function correctly even if an error occurs during the save process.