### PR TITLE
Add missing upgrade steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,14 +167,14 @@ return [
      * register them.
      */
     'auto_discover_settings' => [
-        app()->path(),
+        app_path('Settings'),
     ],
 
     /*
      * Automatically discovered settings classes can be cached so they don't
      * need to be searched each time the application boots up.
      */
-    'discovered_settings_cache_path' => storage_path('app/laravel-settings'),
+    'discovered_settings_cache_path' => base_path('bootstrap/cache'),
 ];
 ```
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,3 +8,43 @@ This should be a quick update:
 
 - When creating a new project, the default search location for settings classes will be in the `app_path('Settings')` directory. If you want to keep the old location, then you can set the `auto_discover_settings` option to `app_path()`. For applications which already have published their config, nothing changes.
 - If you're implementing custom repositories, then update them according to the interface. The method `updatePropertyPayload` is renamed to `updatePropertiesPayload` and should now update multiple properties at once.
+- Add a new migration with the following content
+
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('settings', function (Blueprint $table): void {
+            $table->boolean('locked')->default(false)->change();
+
+            $table->unique(['group', 'name']);
+
+            $table->dropIndex(['group']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('settings', function (Blueprint $table): void {
+            $table->boolean('locked')->default(null)->change();
+
+            $table->dropUnique(['group', 'name']);
+
+            $table->index('group');
+        });
+    }
+};
+```

--- a/database/migrations/create_settings_table.php.stub
+++ b/database/migrations/create_settings_table.php.stub
@@ -11,7 +11,7 @@ return new class extends Migration
         Schema::create('settings', function (Blueprint $table): void {
             $table->id();
 
-            $table->string('group')->index();
+            $table->string('group');
             $table->string('name');
             $table->boolean('locked')->default(false);
             $table->json('payload');


### PR DESCRIPTION
This PR attempts to resolve #217

Technically speaking, just the changes to the upgrade guide are needed. I have added a separate commit for removing the now unnecessary index from the stub migration for the reasons I detail in the linked issue.

I don't think this qualifies as a breaking change, but I can remove that commit if you'd prefer to retain both indexes. I can also remove this line from the example migration in the UPDGRADING.md.