### PR TITLE
Change provider tag name for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ php artisan migrate
 You can publish the config file with:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\LaravelSettings\LaravelSettingsServiceProvider" --tag="settings"
+php artisan vendor:publish --provider="Spatie\LaravelSettings\LaravelSettingsServiceProvider" --tag="config"
 ```
 
 This is the contents of the published config file:

--- a/src/LaravelSettingsServiceProvider.php
+++ b/src/LaravelSettingsServiceProvider.php
@@ -24,7 +24,7 @@ class LaravelSettingsServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__ . '/../config/settings.php' => config_path('settings.php'),
-            ], 'settings');
+            ], 'config');
 
             if (! class_exists('CreateSettingsTable')) {
                 $this->publishes([


### PR DESCRIPTION
Hey there,

I found that "settings" as a publication tag for a **config** file is rather confusing, so...

[Enhancement] Changes include:

- Changed the service provider's tag name for config file publication
- Adjusted the tag name in [README.md]

That's it.