### PR TITLE
Improved Migration Match

### DIFF
--- a/src/LaravelSettingsServiceProvider.php
+++ b/src/LaravelSettingsServiceProvider.php
@@ -75,9 +75,10 @@ class LaravelSettingsServiceProvider extends ServiceProvider
             ->map(function (SplFileInfo $file) {
                 $contents = file_get_contents($file->getRealPath());
 
+                $class = addslashes(SettingsMigration::class);
+
                 if (
-                    str_contains($contents, 'return new class extends '.SettingsMigration::class)
-                    || str_contains($contents, 'return new class extends SettingsMigration')
+                    preg_match("/return\s*new\s*class\s*?\(?\)?\s*extends\s*(?:SettingsMigration|{$class})/", $contents)
                 ) {
                     return $file->getBasename('.php');
                 }

--- a/tests/Migrations/2018_11_21_091111_create_fake_anonymous_class_with_parentheses_settings.php
+++ b/tests/Migrations/2018_11_21_091111_create_fake_anonymous_class_with_parentheses_settings.php
@@ -1,0 +1,14 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsBlueprint;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class () extends SettingsMigration {
+    public function up(): void
+    {
+        $this->migrator->inGroup('anonymous-class-general', function (SettingsBlueprint $migrator) {
+            $migrator->add('name', 'laravel-settings');
+            $migrator->add('organization', 'spatie');
+        });
+    }
+};

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -451,6 +451,7 @@ it('will remigrate when the schema was dumped', function () {
 
     assertDatabaseHas('migrations', ['migration' => '2018_11_21_091111_create_fake_settings']);
     assertDatabaseHas('migrations', ['migration' => '2018_11_21_091111_create_fake_anonymous_class_settings']);
+    assertDatabaseHas('migrations', ['migration' => '2018_11_21_091111_create_fake_anonymous_class_with_parentheses_settings.php']);
     assertDatabaseHas('migrations', ['migration' => '2018_11_21_091111_create_fake_table']);
     assertDatabaseHas('migrations', ['migration' => '2018_11_21_091111_create_fake_anonymous_class_table']);
 
@@ -461,6 +462,7 @@ it('will remigrate when the schema was dumped', function () {
 
     assertDatabaseMissing('migrations', ['migration' => '2018_11_21_091111_create_fake_settings']);
     assertDatabaseMissing('migrations', ['migration' => '2018_11_21_091111_create_fake_anonymous_class_settings']);
+    assertDatabaseMissing('migrations', ['migration' => '2018_11_21_091111_create_fake_anonymous_class_with_parentheses_settings']);
     assertDatabaseHas('migrations', ['migration' => '2018_11_21_091111_create_fake_table']);
     assertDatabaseHas('migrations', ['migration' => '2018_11_21_091111_create_fake_anonymous_class_table']);
 })->skip(fn () => Str::startsWith(app()->version(), '7'), 'No support for dumping migrations in Laravel 7');


### PR DESCRIPTION
Currently, the migration class matching will not match when `()` is properly added to anonymous migration classes. This will make sure that that and all other scenarios are matched.