### PR TITLE
Use Illuminate\Database\Eloquent\Casts\Json if possible

### DIFF
--- a/src/SettingsRepositories/DatabaseSettingsRepository.php
+++ b/src/SettingsRepositories/DatabaseSettingsRepository.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelSettings\SettingsRepositories;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Json;
 use Spatie\LaravelSettings\Models\SettingsProperty;
 
 class DatabaseSettingsRepository implements SettingsRepository
@@ -27,7 +28,7 @@ class DatabaseSettingsRepository implements SettingsRepository
             ->where('group', $group)
             ->get(['name', 'payload'])
             ->mapWithKeys(function (object $object) {
-                return [$object->name => json_decode($object->payload, true)];
+                return [$object->name => $this->decode($object->payload, true)];
             })
             ->toArray();
     }
@@ -48,7 +49,7 @@ class DatabaseSettingsRepository implements SettingsRepository
             ->first('payload')
             ->toArray();
 
-        return json_decode($setting['payload']);
+        return $this->decode($setting['payload']);
     }
 
     public function createProperty(string $group, string $name, $payload): void
@@ -56,7 +57,7 @@ class DatabaseSettingsRepository implements SettingsRepository
         $this->getBuilder()->create([
             'group' => $group,
             'name' => $name,
-            'payload' => json_encode($payload),
+            'payload' => $this->encode($payload),
             'locked' => false,
         ]);
     }
@@ -67,7 +68,7 @@ class DatabaseSettingsRepository implements SettingsRepository
             return [
                 'group' => $group,
                 'name' => $name,
-                'payload' => json_encode($payload),
+                'payload' => $this->encode($payload),
             ];
         })->values()->toArray();
 
@@ -122,5 +123,19 @@ class DatabaseSettingsRepository implements SettingsRepository
         }
 
         return $model->newQuery();
+    }
+
+    private function encode(mixed $value): mixed
+    {
+        return class_exists(Json::class)
+            ? Json::encode($value)
+            : json_encode($value);
+    }
+
+    private function decode(string $payload, bool $associative = false): mixed
+    {
+        return class_exists(Json::class)
+            ? Json::decode($payload, ! $associative)
+            : json_decode($payload, $associative);
     }
 }


### PR DESCRIPTION
Tries to use `Illuminate\Database\Eloquent\Casts\Json` if it is available and falls back to native `json_encode`/`json_decode` otherwise.

This change allows the usage of custom JSON serializers or custom serialization options by defining the following in a service provider:
```php
Json::encodeUsing(fn ($value) => json_encode($value, JSON_UNESCAPED_UNICODE));
```