### PR TITLE
Update composer.json to use Larastan Org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev" : {
         "ext-redis": "*",
         "mockery/mockery": "^1.4",
-        "nunomaduro/larastan": "^2.0",
+        "larastan/larastan": "^2.0",
         "orchestra/testbench": "^6.23|^7.0|^8.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.2",


### PR DESCRIPTION
Starting with Larastan 2.7.0, the Larastan repository will now be managed under the Larastan organization.