### PR TITLE
fix when base path is app path

### DIFF
--- a/src/Console/MakeSettingCommand.php
+++ b/src/Console/MakeSettingCommand.php
@@ -110,7 +110,17 @@ EOT;
 
     protected function getNamespace($path): string
     {
-        $path = trim(str_replace([base_path(), '/'], ['', '\\'], $path), '\\');
+        $path = preg_replace(
+            [
+                '/^(' . preg_quote(base_path(), '/') . ')/',
+                '/\//'
+            ],
+            [
+                '',
+                '\\'
+            ],
+            $path
+        );
 
         return implode('\\', array_map(fn ($directory) => ucfirst($directory), explode('\\', $path)));
     }


### PR DESCRIPTION
I'm working with lando (docker) and there the "src" folder is mounted to "/app".

This is what my path looks like:
/app/app/Settings

Currently the make command replaces all occurrences of base path which results in a wrong namespace "Settings". 