### PR TITLE
Update MakeSettingCommand.php

### DIFF
--- a/src/Console/MakeSettingCommand.php
+++ b/src/Console/MakeSettingCommand.php
@@ -108,20 +108,27 @@ EOT;
         return $path . '/' . $name . '.php';
     }
 
-    protected function getNamespace($path): string
-    {
-        $path = preg_replace(
-            [
-                '/^(' . preg_quote(base_path(), '/') . ')/',
-                '/\//',
-            ],
-            [
-                '',
-                '\\',
-            ],
-            $path
-        );
+protected function getNamespace($path): string
+{
+    $path = preg_replace(
+        [
+            '/^(' . preg_quote(base_path(), '/') . ')/',
+            '/\//',
+        ],
+        [
+            '',
+            '\\',
+        ],
+        $path
+    );
 
-        return implode('\\', array_map(fn ($directory) => ucfirst($directory), explode('\\', $path)));
+    $namespace = implode('\\', array_map(fn ($directory) => ucfirst($directory), explode('\\', $path)));
+
+    // Remove leading backslash if present
+    if (substr($namespace, 0, 1) === '\\') {
+        $namespace = substr($namespace, 1);
     }
+
+    return $namespace;
+}
 }

--- a/src/Console/MakeSettingCommand.php
+++ b/src/Console/MakeSettingCommand.php
@@ -108,27 +108,27 @@ EOT;
         return $path . '/' . $name . '.php';
     }
 
-protected function getNamespace($path): string
-{
-    $path = preg_replace(
-        [
-            '/^(' . preg_quote(base_path(), '/') . ')/',
-            '/\//',
-        ],
-        [
-            '',
-            '\\',
-        ],
-        $path
-    );
+    protected function getNamespace($path): string
+    {
+        $path = preg_replace(
+            [
+                '/^(' . preg_quote(base_path(), '/') . ')/',
+                '/\//',
+            ],
+            [
+                '',
+                '\\',
+            ],
+            $path
+        );
 
-    $namespace = implode('\\', array_map(fn ($directory) => ucfirst($directory), explode('\\', $path)));
+        $namespace = implode('\\', array_map(fn ($directory) => ucfirst($directory), explode('\\', $path)));
 
-    // Remove leading backslash if present
-    if (substr($namespace, 0, 1) === '\\') {
-        $namespace = substr($namespace, 1);
+        // Remove leading backslash if present
+        if (substr($namespace, 0, 1) === '\\') {
+            $namespace = substr($namespace, 1);
+        }
+
+        return $namespace;
     }
-
-    return $namespace;
-}
 }


### PR DESCRIPTION
**Overview**:
This pull request addresses an issue in the `getNamespace()` method where the generated namespace contains a leading backslash (`\`). According to namespace conventions, a namespace should not start with a backslash. This pull request modifies the `getNamespace()` method to remove the leading backslash from the generated namespace.

**Changes**:
- Updated the `getNamespace()` method to check for and remove the leading backslash from the generated namespace.
- Added a conditional check to remove the leading backslash if present in the namespace string.

**Impact**:
- Ensures that the generated namespace conforms to PHP namespace conventions by removing the leading backslash.
- Improves code readability and adherence to best practices.
