### PR TITLE
[3.x] Fix PHP 7.4 Compatibilty

### DIFF
--- a/src/SettingsRepositories/DatabaseSettingsRepository.php
+++ b/src/SettingsRepositories/DatabaseSettingsRepository.php
@@ -124,6 +124,10 @@ class DatabaseSettingsRepository implements SettingsRepository
         return $model->newQuery();
     }
 
+    /**
+     * @param  mixed  $value
+     * @return mixed
+     */
     protected function encode($value)
     {
         $encoder = config('settings.encoder') ?? fn ($value) => json_encode($value);
@@ -131,6 +135,9 @@ class DatabaseSettingsRepository implements SettingsRepository
         return $encoder($value);
     }
 
+    /**
+     * @return mixed
+     */
     protected function decode(string $payload, bool $associative = false)
     {
         $decoder = config('settings.decoder') ?? fn ($payload, $associative) => json_decode($payload, $associative);

--- a/src/SettingsRepositories/DatabaseSettingsRepository.php
+++ b/src/SettingsRepositories/DatabaseSettingsRepository.php
@@ -124,14 +124,14 @@ class DatabaseSettingsRepository implements SettingsRepository
         return $model->newQuery();
     }
 
-    protected function encode(mixed $value): mixed
+    protected function encode($value)
     {
         $encoder = config('settings.encoder') ?? fn ($value) => json_encode($value);
 
         return $encoder($value);
     }
 
-    protected function decode(string $payload, bool $associative = false): mixed
+    protected function decode(string $payload, bool $associative = false)
     {
         $decoder = config('settings.decoder') ?? fn ($payload, $associative) => json_decode($payload, $associative);
 


### PR DESCRIPTION
Recent changes in `src/SettingsRepository/DatabaseSettingsRepository` which introduced `mixed` type hint introduce breaking changes with project running PHP 7.4. This PR attempt to solve the issue by removing the type hint and move them to their respective docblock.

Fixes #263 