### PR TITLE
ADD: down method to migration file

### DIFF
--- a/database/migrations/create_settings_table.php.stub
+++ b/database/migrations/create_settings_table.php.stub
@@ -21,4 +21,9 @@ return new class extends Migration
             $table->unique(['group', 'name']);
         });
     }
+
+    public function down(): void
+	{
+		Schema::dropIfExists('settings');
+	}
 };


### PR DESCRIPTION
Hi,

I recently installed this package and when I run the `php artisan migrate:refresh` command, Laravel throws an exception that the settings table already exists. The issue is that the migration does not include a down method, so the settings table is not removed in migration refresh. So, I added the down method to it.

Let me know if you'd like me to suggest any further changes!