### PR TITLE
Handle Parentheses On Anonymous Settings Migrations

### DIFF
--- a/src/LaravelSettingsServiceProvider.php
+++ b/src/LaravelSettingsServiceProvider.php
@@ -78,6 +78,8 @@ class LaravelSettingsServiceProvider extends ServiceProvider
                 if (
                     str_contains($contents, 'return new class extends '.SettingsMigration::class)
                     || str_contains($contents, 'return new class extends SettingsMigration')
+                    || str_contains($contents, 'return new class() extends '.SettingsMigration::class)
+                    || str_contains($contents, 'return new class() extends SettingsMigration')
                 ) {
                     return $file->getBasename('.php');
                 }

--- a/tests/Migrations/2018_11_21_091111_create_fake_anonymous_class_with_parentheses_settings.php
+++ b/tests/Migrations/2018_11_21_091111_create_fake_anonymous_class_with_parentheses_settings.php
@@ -1,0 +1,14 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsBlueprint;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class() extends SettingsMigration {
+    public function up(): void
+    {
+        $this->migrator->inGroup('anonymous-class-with-parentheses-general', function (SettingsBlueprint $migrator) {
+            $migrator->add('name', 'laravel-settings');
+            $migrator->add('organization', 'spatie');
+        });
+    }
+};

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -453,6 +453,7 @@ it('will remigrate when the schema was dumped', function () {
     assertDatabaseHas('migrations', ['migration' => '2018_11_21_091111_create_fake_anonymous_class_settings']);
     assertDatabaseHas('migrations', ['migration' => '2018_11_21_091111_create_fake_table']);
     assertDatabaseHas('migrations', ['migration' => '2018_11_21_091111_create_fake_anonymous_class_table']);
+    assertDatabaseHas('migrations', ['migration' => '2018_11_21_091111_create_fake_anonymous_class_with_parentheses_settings']);
 
     event(new SchemaLoaded(
         DB::connection(),
@@ -461,6 +462,7 @@ it('will remigrate when the schema was dumped', function () {
 
     assertDatabaseMissing('migrations', ['migration' => '2018_11_21_091111_create_fake_settings']);
     assertDatabaseMissing('migrations', ['migration' => '2018_11_21_091111_create_fake_anonymous_class_settings']);
+    assertDatabaseMissing('migrations', ['migration' => '2018_11_21_091111_create_fake_anonymous_class_with_parentheses_settings']);
     assertDatabaseHas('migrations', ['migration' => '2018_11_21_091111_create_fake_table']);
     assertDatabaseHas('migrations', ['migration' => '2018_11_21_091111_create_fake_anonymous_class_table']);
 })->skip(fn () => Str::startsWith(app()->version(), '7'), 'No support for dumping migrations in Laravel 7');


### PR DESCRIPTION
On some of the projects that I work on, we have PHP-CS-Fixer's [`new_with_parentheses`](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/operator/new_with_parentheses.rst) fixer enabled which means our migrations are formatted with `return new class()`. We were preparing for a Laravel 11 upgrade and doing a schema dump when all of the tests started failing. The underlying cause was that the settings migrations were not getting properly rerun.

This PR adds in support for clearing out Settings migrations that are created with `new class()` and not just `new class`.