### PR TITLE
Add down() in SettingsMigration stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,12 @@ class CreateGeneralSettings extends SettingsMigration
         $this->migrator->add('general.site_name', 'Spatie');
         $this->migrator->add('general.site_active', true);
     }
+
+    public function down(): void
+    {
+        $this->migrator->delete('general.site_name');
+        $this->migrator->delete('general.site_active');
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ class CreateGeneralSettings extends SettingsMigration
 }
 ```
 
-We haven't added a `down` method, but this can be added if desired. In the `up` method, you can change the settings data in the repository when migrating. There are a few default operations supported:
+We have added a `down` method, but this can be ignored if desired. In the `up` method, you can change the settings data in the repository when migrating. In the `down` method, you can revert the changes when rolling back the migration. There are a few default operations supported:
 
 #### Adding a property
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,11 @@ class CreateGeneralSettings extends SettingsMigration
     {
 
     }
+
+    public function down(): void
+    {
+
+    }
 }
 ```
 

--- a/src/Console/MakeSettingsMigrationCommand.php
+++ b/src/Console/MakeSettingsMigrationCommand.php
@@ -58,6 +58,11 @@ return new class extends SettingsMigration
     {
 
     }
+
+    public function down(): void
+    {
+    
+    }
 };
 
 EOT;


### PR DESCRIPTION
When adding a setting using migration in the table, the stub does not have a down function.

Adding a `delete` command in the `down` function using migrators can help roll back the migrations for settings.