### PR TITLE
Feat: add exists in migrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,18 @@ public function up(): void
 }
 ```
 
+#### Checking a property if it exists
+
+There might be times when you want to check if a property exists in the database. This can be done as such:
+
+```php
+public function up(): void
+{
+    if ($this->migrator->exists('general.timezone')) {
+        // do something
+    }
+}
+
 #### Operations in group
 
 When you're working on a big settings class with many properties, it can be a bit cumbersome always to have to prepend the settings group. That's why you can also perform operations within a settings group:

--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ public function up(): void
         // do something
     }
 }
+```
 
 #### Operations in group
 

--- a/src/Migrations/SettingsMigrator.php
+++ b/src/Migrations/SettingsMigrator.php
@@ -114,6 +114,11 @@ class SettingsMigrator
         $this->update($property, fn ($payload) => Crypto::decrypt($payload));
     }
 
+    public function exists(string $property): bool
+    {
+        return $this->checkIfPropertyExists($property);
+    }
+
     public function inGroup(string $group, Closure $closure): void
     {
         $closure(new SettingsBlueprint($group, $this));

--- a/tests/SettingsMigratorTest.php
+++ b/tests/SettingsMigratorTest.php
@@ -100,6 +100,16 @@ it('cannot update a setting that does not exist', function () {
     $this->settingsMigrator->update('user.name', fn (string $name) => 'Ruben Van Assche');
 })->throws(SettingDoesNotExist::class);
 
+it('can check if a setting exists', function () {
+    $this->settingsMigrator->add('settings.exists', true);
+
+    expect($this->settingsMigrator->exists('settings.exists'))->toBeTrue();
+});
+
+it('can check if a setting does not exists', function () {
+    expect($this->settingsMigrator->exists('settings.does_not_exists'))->toBeFalse();
+});
+
 it('can perform migrations within a group', function () {
     $this->settingsMigrator->inGroup('test', function (SettingsBlueprint $blueprint): void {
         $blueprint->add('a', 'Alpha');


### PR DESCRIPTION
As Spatie doesn't use `down()` methods in the migrations, I cam across a problem and had to rollback my migrations which included some settings migration as well. But as `down()` wasn't available, it threw me an error when the migration tried to re-insert the value in settings

So, I propose providing a function `exists()` in the migrator to check if the settings exist already. As there's no way to know if the setting exists or not.