### PR TITLE
Fill missing settings with default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,17 @@ You should migrate your database to add the properties:
 php artisan migrate
 ```
 
+Without the migration, if you try to load the `GeneralSettings` settings class, it will throw `MissingSettings` exception. To avoid this, you can define default values for each attribute. This can be useful if you have long-running migrations.
+
+```php
+    // Will throw an error
+    public ?string $site_name;
+    // Will return `null`
+    public ?string $site_description = null;
+    // Will return `false`
+    public bool $site_active = false;
+```
+
 Now, when you want to use the `site_name` property of the `GeneralSettings` settings class, you can inject it into your application:
 
 ```php

--- a/src/SettingsMapper.php
+++ b/src/SettingsMapper.php
@@ -117,9 +117,9 @@ class SettingsMapper
             ->each(function($missingSetting) use ($config, &$properties) {
                 /** @var ReflectionProperty $reflectionProperty */
                 $reflectionProperty = $config->getReflectedProperties()[$missingSetting];
-                $defaultValue = $reflectionProperty->getDefaultValue();
-                if (! is_null($defaultValue) || $reflectionProperty->getType()->allowsNull()) {
-                    $properties->put($missingSetting, $defaultValue);
+
+                if ($reflectionProperty->hasDefaultValue() || $reflectionProperty->getType()->allowsNull()) {
+                    $properties->put($missingSetting, $reflectionProperty->getDefaultValue());
                 }
             });
 

--- a/src/SettingsMapper.php
+++ b/src/SettingsMapper.php
@@ -118,14 +118,14 @@ class SettingsMapper
                 /** @var ReflectionProperty $reflectionProperty */
                 $reflectionProperty = $config->getReflectedProperties()[$missingSetting];
 
-                if ($reflectionProperty->hasDefaultValue() || $reflectionProperty->getType()->allowsNull()) {
+                if ($reflectionProperty->hasDefaultValue()) {
                     $properties->put($missingSetting, $reflectionProperty->getDefaultValue());
                 }
             });
 
         return $properties;
     }
-    
+
     private function ensureNoMissingSettings(
         SettingsConfig $config,
         Collection     $properties,

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -51,7 +51,7 @@ it('will handle loading settings correctly', function () {
     $carbon = new Carbon('16-05-1994 12:00:00');
     $illuminateCarbon = new IlluminateCarbon('20-05-1994 12:00:00');
 
-    $this->migrator->inGroup('dummy', function (SettingsBlueprint $blueprint) use ($carbon, $dateTime): void {
+    $this->migrator->inGroup('dummy', function (SettingsBlueprint $blueprint) use ($carbon, $dateTime, $illuminateCarbon): void {
         $blueprint->add('string', 'Ruben');
         $blueprint->add('bool', false);
         $blueprint->add('int', 42);
@@ -113,7 +113,7 @@ it('can save settings', function () {
     $illuminateCarbon = new IlluminateCarbon('20-05-1994 12:00:00');
     $dateTimeZone = new DateTimeZone('europe/brussels');
 
-    $this->migrator->inGroup('dummy', function (SettingsBlueprint $blueprint) use ($dateTimeZone, $carbon, $dateTime): void {
+    $this->migrator->inGroup('dummy', function (SettingsBlueprint $blueprint) use ($dateTimeZone, $carbon, $dateTime, $illuminateCarbon): void {
         $blueprint->add('string', 'Ruben');
         $blueprint->add('bool', false);
         $blueprint->add('int', 42);

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -93,6 +93,14 @@ it('will fail loading when settings are missing', function () {
     resolve(DummySettings::class)->int;
 })->throws(MissingSettings::class);
 
+it('will fail loading when settings are missing and no default value is present', function () {
+    resolve(DummySettings::class)->nullable_string;
+})->throws(MissingSettings::class);
+
+it('will return default when settings are missing and default value is present', function () {
+    expect(resolve(DummySettings::class))->nullable_string_default->toEqual('default');
+})->throws(MissingSettings::class);
+
 it('cannot get settings that do not exist', function () {
     $this->migrateDummySimpleSettings();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -80,6 +80,7 @@ class TestCase extends BaseTestCase
 
             $blueprint->add('date_time', $date->toAtomString());
             $blueprint->add('carbon', $date->toAtomString());
+            $blueprint->add('illuminate_carbon', $date->toAtomString());
             $blueprint->add('nullable_date_time_zone', 'europe/brussels');
         });
 

--- a/tests/TestClasses/DummySettings.php
+++ b/tests/TestClasses/DummySettings.php
@@ -20,6 +20,9 @@ class DummySettings extends Settings
 
     public ?string $nullable_string;
 
+    public ?string $nullable_string_default = 'default';
+
+
     public DummyData $dto;
 
     /** @var \Spatie\LaravelSettings\Tests\TestClasses\DummyData[] */

--- a/tests/TestClasses/DummySettings.php
+++ b/tests/TestClasses/DummySettings.php
@@ -7,6 +7,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Spatie\LaravelSettings\Settings;
 use Spatie\LaravelSettings\SettingsCasts\DataCast;
+use Illuminate\Support\Carbon as IlluminateCarbon;
 
 class DummySettings extends Settings
 {
@@ -34,6 +35,8 @@ class DummySettings extends Settings
     public DateTimeImmutable $date_time;
 
     public Carbon $carbon;
+
+    public IlluminateCarbon $illuminate_carbon;
 
     public ?DateTimeZone $nullable_date_time_zone;
 

--- a/tests/TestClasses/DummySettings.php
+++ b/tests/TestClasses/DummySettings.php
@@ -22,7 +22,6 @@ class DummySettings extends Settings
 
     public ?string $nullable_string_default = 'default';
 
-
     public DummyData $dto;
 
     /** @var \Spatie\LaravelSettings\Tests\TestClasses\DummyData[] */


### PR DESCRIPTION
Currently if you deploy a new version to a server and the migrations are still running you get a `MissingSettings` exception. For long running migrations and big deployments this can be a problem.

This proposal adds a fallback option to settings defined in the `Settings` object. If you set the default in the code the settings mapper will return that default value instead of throwing an exception. For nullable values the default will be null without changing anything in the `Settings` object.

 Example:

```
    // Returns false without migrations
    public bool $mySetting = false;
    // Returns null
    public ?string $myOtherSetting;
    // Fails
    public string $myOtherSetting;
```

What do you think about this proposal?

Credits to @andrasszommer