### PR TITLE
add getModel() to Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,27 @@ class SettingsController
 }
 ```
 
+You can get the model of a perticular settings class with getModel():
+
+```php
+class IndexController
+{
+    public function __invoke(GeneralSettings $settings){
+        return view('index', [
+            'settings_model' => $settings->getModel(),
+        ]);
+    }
+}
+
+/*
+
+Settings::getModel() returns an array:
+ [
+    "site_name" => [ "type" => "string", "nullable" => false ]
+ ]
+*/
+```
+
 ### Selecting a repository
 
 Settings will be stored and loaded from the repository. There are two types of repositories `database` and `redis`. And it is possible to create multiple repositories for these types. For example, you could have two `database` repositories, one that goes to a `settings` table in your database and another that goes to a `global_settings` table.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -298,4 +298,10 @@ abstract class Settings implements Arrayable, Jsonable, Responsable
 
         return $this;
     }
+    
+    public function getModel(): array
+    {
+        $settingsTypes = SettingsInspector::getSettingsTypes($this);
+        return $settingsTypes;
+    }
 }

--- a/src/SettingsInspector.php
+++ b/src/SettingsInspector.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Spatie\LaravelSettings;
+
+use Spatie\LaravelSettings\Settings;
+use ReflectionClass;
+use ReflectionProperty;
+
+class SettingsInspector
+{
+    public static function getSettingsTypes(array|Settings $settingsClasses): array
+    {
+        $settingsCasts = [];
+
+        if ( $settingsClasses instanceof Settings ) {
+            $reflection = new ReflectionClass($settingsClasses);
+            $properties = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
+            
+            foreach ($properties as $property) {
+                $type = $property->getType();
+                $typeName = $type ? $type->getName() : 'mixed';
+
+                $settingsCasts[$property->getName()] = [
+                    'type' => $typeName,
+                    'nullable' => $type ? $type->allowsNull() : false,
+                ];
+            }
+
+        } elseif ( is_array($settingsClasses) ) {
+            foreach ($settingsClasses as $group => $settingsClass) {
+                $reflection = new ReflectionClass($settingsClass);
+                $properties = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
+    
+                foreach ($properties as $property) {
+                    $type = $property->getType();
+                    $typeName = $type ? $type->getName() : 'mixed';
+    
+                    $settingsCasts[$group][$property->getName()] = [
+                        'type' => $typeName,
+                        'nullable' => $type ? $type->allowsNull() : false,
+                    ];
+                }
+            }
+        }
+
+        return $settingsCasts;
+    }
+}

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -782,3 +782,23 @@ it('it can use enums which are null', function () {
 
     expect($settings->name)->toBeNull();
 });
+
+it('can use getModel', function() {
+    $this->migrateDummySettings(CarbonImmutable::create('2020-05-16')->startOfDay());
+
+    $settings = resolve(DummySettings::class);
+
+    $model = $settings->getModel();
+
+    expect($model)
+        ->toBeArray()
+        ->string->toBeArray()
+        ->string->type->toEqual('string')
+        ->string->nullable->toEqual(false)
+        ->int->toBeArray()
+        ->int->type->toEqual('int')
+        ->int->nullable->toEqual(false)
+        ->nullable_string->toBeArray()
+        ->nullable_string->type->toEqual('string')
+        ->nullable_string->nullable->toEqual(true);
+});


### PR DESCRIPTION
Settings::getModel() implements a simple way to get the types/nullable status of the actual settings instance. Work is done via an additional SettingsInspector class.