### PR TITLE
Do not save settings with missing migrations

### DIFF
--- a/src/SettingsConfig.php
+++ b/src/SettingsConfig.php
@@ -16,6 +16,8 @@ class SettingsConfig
     /** @var class-string<\Spatie\LaravelSettings\Settings> */
     private string $settingsClass;
 
+    private Collection $propertiesWithDefaultValues;
+
     /** @var Collection<string, ?\Spatie\LaravelSettings\SettingsCasts\SettingsCast> */
     private Collection $casts;
 
@@ -121,6 +123,25 @@ class SettingsConfig
         return $this->locked = collect(
             $this->repository->getLockedProperties($this->settingsClass::group())
         );
+    }
+
+    public function addDefaultValueProperty(string ...$names): self
+    {
+        $this->propertiesWithDefaultValues = $this->getPropertiesWithDefaultValues()->push(...$names);
+
+        return $this;
+    }
+
+    public function getPropertiesWithDefaultValues(): Collection
+    {
+        return $this->propertiesWithDefaultValues;
+    }
+
+    public function clearPropertiesWithDefaultValues(): self
+    {
+        $this->propertiesWithDefaultValues = collect([]);
+
+        return $this;
     }
 
     public function clearCachedLockedProperties(): self

--- a/src/SettingsMapper.php
+++ b/src/SettingsMapper.php
@@ -11,6 +11,7 @@ class SettingsMapper
 {
     /** @var array<string, \Spatie\LaravelSettings\SettingsConfig> */
     private array $configs = [];
+    private array $propertiesWithDefaultValues = [];
 
     public function initialize(string $settingsClass): SettingsConfig
     {
@@ -119,6 +120,7 @@ class SettingsMapper
                 $reflectionProperty = $config->getReflectedProperties()[$missingSetting];
 
                 if ($reflectionProperty->hasDefaultValue()) {
+                    $this->propertiesWithDefaultValues[] = $missingSetting;
                     $properties->put($missingSetting, $reflectionProperty->getDefaultValue());
                 }
             });
@@ -135,6 +137,7 @@ class SettingsMapper
             ->getReflectedProperties()
             ->keys()
             ->diff($properties->keys())
+            ->when($operation === 'saving', fn($collection) => $collection->concat($this->propertiesWithDefaultValues))
             ->toArray();
 
         if (! empty($missingSettings)) {

--- a/src/SettingsMapper.php
+++ b/src/SettingsMapper.php
@@ -11,7 +11,6 @@ class SettingsMapper
 {
     /** @var array<string, \Spatie\LaravelSettings\SettingsConfig> */
     private array $configs = [];
-    private array $propertiesWithDefaultValues = [];
 
     public function initialize(string $settingsClass): SettingsConfig
     {
@@ -111,6 +110,8 @@ class SettingsMapper
 
     private function fillMissingSettingsWithDefaultValues(SettingsConfig $config, Collection $properties): Collection
     {
+        $config->clearPropertiesWithDefaultValues();
+
         $config
             ->getReflectedProperties()
             ->keys()
@@ -120,7 +121,7 @@ class SettingsMapper
                 $reflectionProperty = $config->getReflectedProperties()[$missingSetting];
 
                 if ($reflectionProperty->hasDefaultValue()) {
-                    $this->propertiesWithDefaultValues[] = $missingSetting;
+                    $config->addDefaultValueProperty($missingSetting);
                     $properties->put($missingSetting, $reflectionProperty->getDefaultValue());
                 }
             });
@@ -137,7 +138,7 @@ class SettingsMapper
             ->getReflectedProperties()
             ->keys()
             ->diff($properties->keys())
-            ->when($operation === 'saving', fn($collection) => $collection->concat($this->propertiesWithDefaultValues))
+            ->when($operation === 'saving', fn($collection) => $collection->concat($config->getPropertiesWithDefaultValues()))
             ->toArray();
 
         if (! empty($missingSettings)) {

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -78,6 +78,7 @@ it('will handle loading settings correctly', function () {
         ->int->toEqual(42)
         ->array->toEqual(['John', 'Ringo', 'Paul', 'George'])
         ->nullable_string->toBeNull()
+        ->nullable_string_default->toEqual('default')
         ->dto->toEqual(DummyData::from(['name' => 'Freek']))
         ->dto_array->toEqual([
             DummyData::from(['name' => 'Seb']),
@@ -85,6 +86,9 @@ it('will handle loading settings correctly', function () {
         ])
         ->date_time->toEqual($dateTime)
         ->carbon->toEqual($carbon);
+
+        // nullable_string_default should throw an error on save because no migration is present
+        expect(fn() => $settings->save())->toThrow(MissingSettings::class);
 });
 
 it('will fail loading when settings are missing', function () {
@@ -117,6 +121,7 @@ it('can save settings', function () {
         $blueprint->add('int', 42);
         $blueprint->add('array', ['John', 'Ringo', 'Paul', 'George']);
         $blueprint->add('nullable_string', null);
+        $blueprint->add('nullable_string_default', 'default2');
         $blueprint->add('default_string', null);
         $blueprint->add('dto', ['name' => 'Freek']);
         $blueprint->add('dto_array', [
@@ -141,6 +146,7 @@ it('can save settings', function () {
         'int' => 69,
         'array' => ['Bono', 'Adam', 'The Edge'],
         'nullable_string' => null,
+        'nullable_string_default' => 'modified',
         'default_string' => 'another',
         'dto' => DummyData::from(['name' => 'Rias']),
         'dto_array' => [
@@ -157,6 +163,7 @@ it('can save settings', function () {
     $settings->save();
 
     $this->assertDatabaseHasSetting('dummy.string', 'Brent');
+    $this->assertDatabaseHasSetting('dummy.nullable_string_default', 'modified');
     $this->assertDatabaseHasSetting('dummy.bool', true);
     $this->assertDatabaseHasSetting('dummy.int', 69);
     $this->assertDatabaseHasSetting('dummy.array', ['Bono', 'Adam', 'The Edge']);


### PR DESCRIPTION
This pull request is the continuation on the following change: https://github.com/spatie/laravel-settings/pull/298

Based on feedback I've received, we should not allow saving with not migrated default value properties. If the save happens the migration will fail because the row already exists in the database.

also credit to @netpok