### PR TITLE
Allow configuring whether to check missing default values when saving settings

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -91,4 +91,12 @@ return [
      * need to be searched each time the application boots up.
      */
     'discovered_settings_cache_path' => base_path('bootstrap/cache'),
+
+    /*
+     * Whether to check and throw the {@see \Spatie\LaravelSettings\Exceptions\MissingSettings} exception when saving
+     * settings whose default values are not migrated yet.
+     *
+     * Set `false` to silently ignore any missing defaults and save settings.
+     */
+    'check_missing_default_values_when_saving_settings' => true,
 ];

--- a/src/SettingsMapper.php
+++ b/src/SettingsMapper.php
@@ -141,7 +141,10 @@ class SettingsMapper
             ->getReflectedProperties()
             ->keys()
             ->diff($properties->keys())
-            ->when($operation === 'saving', fn (Collection $collection) => $collection->concat($config->getDefaultValueLoadedProperties()))
+            ->when(
+                $operation === 'saving' && config('settings.check_missing_default_values_when_saving_settings'),
+                fn (Collection $collection) => $collection->concat($config->getDefaultValueLoadedProperties()),
+            )
             ->toArray();
 
         if (! empty($missingSettings)) {

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -228,6 +228,18 @@ it('can save settings with a default value when correctly migrated', function ()
     $this->assertDatabaseHasSetting('dummy_settings_with_default_value.site', 'mailcoach.app');
 });
 
+it('can save a settings class whose default values are not migrated when checking is disabled', function () {
+    $settings = resolve(DummySettingsWithDefaultValue::class);
+
+    config()->set('settings.check_missing_default_values_when_saving_settings', false);
+
+    $settings->save();
+
+    config()->set('settings.check_missing_default_values_when_saving_settings', true);
+
+    $this->assertDatabaseHasSetting('dummy_settings_with_default_value.site', 'spatie.be');
+});
+
 it('can fake settings', function () {
     $this->migrateDummySimpleSettings();
 


### PR DESCRIPTION
Based on https://github.com/spatie/laravel-settings/pull/313#issuecomment-2829593696, this PR adds a config option to skip checking non-migrated default values when saving settings.

## Reasoning

The idea is to allow using saving settings even if migrations take a while to complete, or when one does not want to use settings migrations at all.

The latter may sound odd at first, but when Settings classes declare default values, it would allow adding new settings without creating migrations. The new settings with their default values would be "migrated" just-in-time, when the user first saves the settings. This is especially helpful in multi-tenancy apps, where each tenant (user) has their own set of settings.

### Backgrounnd

I don't really see a reason to throw an exception when trying to save settings with default values, if there's nothing in the database 🤔 ...
Perhaps I am missing something, but this PR does not change the default behaviour, it only provides a lever for those of us who like to live on the edge 😂 

### Naming and docs

Please note that there's no docs yet, as I wanted to gauge if a PR like this would even be considered, first. If the general approach is acceptable, we can discuss naming and implementation details, and then write the docs.

### Misc

At first, I thought of using a generic `throw_on_missing_settings` config value, but realized that would mean if a settings class does not have default values defined, then accessing such a property, or converting the class to an array would still throw a runtime error, so it wouldn't really buy anything.