### PR TITLE
Fixed missing down method in migration

### DIFF
--- a/database/migrations/create_settings_table.php.stub
+++ b/database/migrations/create_settings_table.php.stub
@@ -21,4 +21,9 @@ return new class extends Migration
             $table->unique(['group', 'name']);
         });
     }
+
+    public function down()
+    {
+        Schema::dropIfExists('settings');
+    }
 };


### PR DESCRIPTION
Fixed missing down method in create_settings_table migration.