### PR TITLE
Register the auto discover cache and clear commands as optimize commands

### DIFF
--- a/src/LaravelSettingsServiceProvider.php
+++ b/src/LaravelSettingsServiceProvider.php
@@ -39,6 +39,12 @@ class LaravelSettingsServiceProvider extends ServiceProvider
                 ClearDiscoveredSettingsCacheCommand::class,
                 ClearCachedSettingsCommand::class,
             ]);
+
+            $this->optimizes(
+                optimize: CacheDiscoveredSettingsCommand::class,
+                clear: ClearDiscoveredSettingsCacheCommand::class,
+                key: 'laravel-settings',
+            );
         }
 
         Event::subscribe(SettingsEventSubscriber::class);


### PR DESCRIPTION
This registers the auto discover cache and clear commands to be called [when Laravel's `optimize` and `optimize:clear` commands are called](https://laravel.com/docs/12.x/packages#optimize-commands) based on [spatie/laravel-data](https://github.com/spatie/laravel-data/blob/32e8adc466bc11289288096bdd0036b06cf39fec/src/LaravelDataServiceProvider.php#L84-L87).

Due to the nested nature of how `optimize` and `optimize:clear` call other commands, I was not able to find a way to create tests for this.