### PR TITLE
Add documentation for using different repository in migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,17 @@ public function up(): void
 }
 ```
 
+#### Using different repositories
+
+You can use a different repository in migration:
+
+```php
+public function up(): void
+{
+    $this->migrator->repository('redis');
+}
+```
+
 ### Typing properties
 
 It is possible to create a settings class with regular PHP types:


### PR DESCRIPTION
It took me quite some time to figure out how to use a different repository in migrations since this wasn't documented. Added documentation for the repository() method to help other developers save time.