### PR TITLE
Update migration file publishing with timestamp

### DIFF
--- a/src/LaravelSettingsServiceProvider.php
+++ b/src/LaravelSettingsServiceProvider.php
@@ -27,10 +27,14 @@ class LaravelSettingsServiceProvider extends ServiceProvider
             ], 'config');
 
             if (! class_exists('CreateSettingsTable')) {
+                $timestamp = date('Y_m_d_His');
+                $destination = database_path("migrations/{$timestamp}_create_settings_table.php");
+            
                 $this->publishes([
-                    __DIR__ . '/../database/migrations/create_settings_table.php.stub' => database_path('migrations/2022_12_14_083707_create_settings_table.php'),
+                    __DIR__ . '/../database/migrations/create_settings_table.php.stub' => $destination,
                 ], 'migrations');
             }
+
 
             $this->commands([
                 MakeSettingCommand::class,


### PR DESCRIPTION
This pull request introduces a small but important improvement to the migration publishing logic in the `LaravelSettingsServiceProvider`. The main change is to ensure that published migration files use the current timestamp in their filename, which helps prevent migration collisions and follows Laravel's conventions.

Migration publishing improvements:

* The migration file published from `create_settings_table.php.stub` now uses the current timestamp in its filename, rather than a hardcoded date, by setting `$destination` to `database/migrations/{$timestamp}_create_settings_table.php`.