### PR TITLE
cast env('SETTINGS_CACHE_ENABLED') to boolean

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -61,7 +61,7 @@ return [
      * additional prefix.
      */
     'cache' => [
-        'enabled' => env('SETTINGS_CACHE_ENABLED', false),
+        'enabled' => (bool)env('SETTINGS_CACHE_ENABLED', false),
         'store' => null,
         'prefix' => null,
         'ttl' => null,


### PR DESCRIPTION
having `SETTINGS_CACHE_ENABLED"` in `phpunit.xml`  

`config('settings.cache.enabled')` returns empty string `""`

```xml
<php>
        <env name="APP_ENV" value="testing"/>
        <env name="SETTINGS_CACHE_ENABLED" value="false"/>
</php>
```