### PR TITLE
Adds a cache prefix resolver

### DIFF
--- a/src/SettingsCache.php
+++ b/src/SettingsCache.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelSettings;
 
+use Closure;
 use DateInterval;
 use DateTimeInterface;
 use Illuminate\Contracts\Cache\Repository;
@@ -12,6 +13,8 @@ use Spatie\LaravelSettings\Exceptions\SettingsCacheDisabled;
 
 class SettingsCache
 {
+    private static ?Closure $prefixResolver = null;
+
     public function __construct(
         private bool $enabled,
         private ?string $store,
@@ -19,6 +22,17 @@ class SettingsCache
         private DateTimeInterface|DateInterval|int|null $ttl = null,
         private bool $memo = false,
     ) {
+    }
+
+    /**
+     * Register a callback that returns a dynamic prefix appended after the
+     * static config prefix. Call with null to remove the resolver.
+     */
+    public static function resolvePrefixUsing(?callable $resolver): void
+    {
+        static::$prefixResolver = $resolver !== null
+            ? Closure::fromCallable($resolver)
+            : null;
     }
 
     public function isEnabled(): bool
@@ -91,6 +105,13 @@ class SettingsCache
     private function resolveCacheKey(string $settingsClass): string
     {
         $prefix = $this->prefix ? "{$this->prefix}." : '';
+
+        if (static::$prefixResolver !== null) {
+            $resolvedPrefix = (string)(static::$prefixResolver)();
+            if ($resolvedPrefix !== '') {
+                $prefix .= "{$resolvedPrefix}.";
+            }
+        }
 
         return "{$prefix}settings.{$settingsClass::cacheKey()}";
     }

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -27,6 +27,7 @@ use Spatie\LaravelSettings\Migrations\SettingsBlueprint;
 use Spatie\LaravelSettings\Migrations\SettingsMigrator;
 use Spatie\LaravelSettings\Models\SettingsProperty;
 use Spatie\LaravelSettings\Settings;
+use Spatie\LaravelSettings\SettingsCache;
 use Spatie\LaravelSettings\Support\SettingsCacheFactory;
 use Spatie\LaravelSettings\Tests\Fakes\FakeSettingsContainer;
 use Spatie\LaravelSettings\Tests\TestClasses\DummyData;
@@ -815,6 +816,32 @@ it('will use specific repository cache settings when supplied', function () {
     expect($log)->toHaveCount(0);
 });
 
+
+it('uses the resolved prefix when reading and writing to cache', function () {
+    useEnabledCache($this->app);
+
+    SettingsCache::resolvePrefixUsing(fn () => 'context-a');
+
+    resolve(SettingsCacheFactory::class)->build()->put(
+        new DummySimpleSettings(['name' => 'Context A', 'description' => 'desc'])
+    );
+
+    $this->setRegisteredSettings([DummySimpleSettings::class]);
+
+    // context-a prefix → cache hit, no DB query
+    expect(resolve(DummySimpleSettings::class)->name)->toEqual('Context A');
+
+    // switching to a different prefix → cache miss for context-b
+    SettingsCache::resolvePrefixUsing(fn () => 'context-b');
+
+    $this->migrateDummySimpleSettings(name: 'Context B');
+
+    app()->forgetScopedInstances();
+
+    expect(resolve(DummySimpleSettings::class)->name)->toEqual('Context B');
+
+    SettingsCache::resolvePrefixUsing(null);
+});
 
 it('it can use enums which are null', function () {
     $this->skipIfPHPLowerThen('8.1');


### PR DESCRIPTION
## Background

  [PR #344](https://github.com/spatie/laravel-settings/pull/344) introduced `cacheKey()` as an override point to fix cache collisions in multi-tenant applications. However, it requires overriding `cacheKey()` in every single Settings class — easy to forget and error-prone.

  ## What this PR does

  Adds a static `resolvePrefixUsing()` method to `SettingsCache` that accepts a callable returning a dynamic prefix. The resolved value is appended after the static config prefix when building cache keys, giving each context its own isolated cache entries.

This is a single, central place to configure - no changes needed to individual Settings classes.

  ## Usage

  With [spatie/laravel-multitenancy](https://github.com/spatie/laravel-multitenancy), create a switch task:

  ```php
  use Spatie\LaravelSettings\SettingsCache;
  use Spatie\Multitenancy\Models\Tenant;
  use Spatie\Multitenancy\Tasks\SwitchTenantTask;

  class SwitchSettingsTask implements SwitchTenantTask
  {
      public function makeCurrent(Tenant $tenant): void
      {
          SettingsCache::resolvePrefixUsing(fn () => $tenant->id);
      }

      public function forgetCurrent(): void
      {
          SettingsCache::resolvePrefixUsing(null);
      }
  }